### PR TITLE
test: add inspect API coverage

### DIFF
--- a/tests/unit/api.test.js
+++ b/tests/unit/api.test.js
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { TurboMini } from '../../src/turbomini.js';
+
+test('inspect lists registered routes, templates, helpers and default mode', () => {
+  const app = TurboMini('/');
+  app.controller('home', () => {});
+  app.template('tpl', '<p></p>');
+  app.registerHelper('noop', (v) => v);
+  const info = app.inspect();
+  assert.ok(info.routes.includes('home'));
+  assert.ok(info.templates.includes('tpl'));
+  assert.ok(info.helpers.includes('noop'));
+  assert.equal(info.mode, 'history');
+});
+
+test('inspect reports hash router mode', () => {
+  const app = TurboMini('#');
+  app.controller('hash', () => {});
+  app.template('t', '<p></p>');
+  app.registerHelper('h', (v) => v);
+  const info = app.inspect();
+  assert.ok(info.routes.includes('hash'));
+  assert.ok(info.templates.includes('t'));
+  assert.ok(info.helpers.includes('h'));
+  assert.equal(info.mode, 'hash');
+});


### PR DESCRIPTION
## Summary
- add unit tests ensuring inspect() reports registered routes, templates, helpers, and router mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4b7691f088333867eb8f4267e8e75