### PR TITLE
Fix worker module initialization in scheduler tests

### DIFF
--- a/tests/unit/scheduler.test.js
+++ b/tests/unit/scheduler.test.js
@@ -7,7 +7,7 @@ const wait = (ms) => new Promise((r) => setTimeout(r, ms));
 
 const runWorker = (code) =>
   new Promise((resolve, reject) => {
-    const worker = new Worker(code, { eval: true });
+    const worker = new Worker(code, { eval: true, type: 'module' });
     worker.on('message', (msg) => resolve(msg));
     worker.on('error', reject);
     worker.on('exit', (c) => c && reject(new Error(`exit ${c}`)));


### PR DESCRIPTION
## Summary
- ensure worker threads in scheduler tests run in ESM mode to allow `import` statements

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4c09e367c833394ea4047a656b1a9