### PR TITLE
test: verify type exports

### DIFF
--- a/tests/unit/types.test.mjs
+++ b/tests/unit/types.test.mjs
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import { writeFileSync, rmSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+
+// Ensure the type definitions export TurboMini and TurboMiniApp
+// by compiling a small TypeScript usage sample with tsc --noEmit.
+test('types export TurboMini and TurboMiniApp', () => {
+  const tsFile = join(process.cwd(), 'tests', 'unit', `types-${process.pid}.ts`);
+  writeFileSync(
+    tsFile,
+    "import TurboMini, { TurboMiniApp } from '../../types/turbomini';\n" +
+      "const app: TurboMiniApp = TurboMini('/');\n"
+  );
+  const tscPath = join(
+    process.cwd(),
+    'node_modules',
+    'typescript',
+    'bin',
+    'tsc'
+  );
+  try {
+    execFileSync(process.execPath, [tscPath, '--noEmit', tsFile], {
+      stdio: 'pipe',
+    });
+  } finally {
+    rmSync(tsFile);
+  }
+});


### PR DESCRIPTION
## Summary
- test type definitions by compiling a TurboMini usage example with tsc

## Testing
- `npm test` *(fails: Cannot find package 'jsdom')*
- `npm run lint` *(fails: 'document' is not defined in diff.test.js)*


------
https://chatgpt.com/codex/tasks/task_e_68c4e3c2523483339f33ee9305cfafd5