### PR TITLE
Add navigation and templating E2E tests

### DIFF
--- a/examples/00-hello-world/index.html
+++ b/examples/00-hello-world/index.html
@@ -6,6 +6,7 @@
       import { TurboMini } from '../../src/turbomini.js';
 
       const app = TurboMini('/examples/00-hello-world');
+      window.app = app;
 
       app.template('default', '<h1>Hello {{name}}</h1>');
       app.controller('default', () => ({ name: 'TurboMini' }));

--- a/tests/e2e/basic.spec.mjs
+++ b/tests/e2e/basic.spec.mjs
@@ -5,3 +5,12 @@ test('hello renders', async ({ page, serverURL }) => {
   await page.goto(`${serverURL}/`);
   await expect(page.locator('h1')).toHaveText('Hello TurboMini');
 });
+
+test('default route under examples path', async ({ page, serverURL }) => {
+  await page.goto(`${serverURL}/examples/00-hello-world/index.html`);
+  await page.evaluate(() => {
+    history.pushState({}, '', '/examples/00-hello-world/');
+    window.app.start();
+  });
+  await expect(page.locator('h1')).toHaveText('Hello TurboMini');
+});

--- a/tests/e2e/hash.html
+++ b/tests/e2e/hash.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+  <body>
+    <page></page>
+    <script type="module">
+      import { TurboMini } from '../../src/turbomini.js';
+      const app = TurboMini('#');
+      app.template('default', '<a id="hash-link" href="#/second" onclick="app.goto(\'/second\'); return false;">Go</a><h1 id="home">Home</h1>');
+      app.template('second', '<h1 id="hash-second">Second</h1>');
+      app.controller('default', () => ({}));
+      app.controller('second', () => ({}));
+      app.start();
+      window.app = app;
+    </script>
+  </body>
+</html>

--- a/tests/e2e/helpers.html
+++ b/tests/e2e/helpers.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+  <body>
+    <page></page>
+    <script type="module">
+      import { TurboMini } from '../../src/turbomini.js';
+      const app = TurboMini('/tests/e2e/helpers.html');
+
+      app.template('default', `
+        <div id="comp">{{json user}}</div>
+        <div id="box" class="{{classList boxClasses}}">Box</div>
+      `);
+      app.controller('default', () => app.state);
+      app.state.user = { name: 'Alice & Bob' };
+      app.state.boxClasses = { active: false };
+      app.start();
+      window.app = app;
+    </script>
+  </body>
+</html>

--- a/tests/e2e/history.html
+++ b/tests/e2e/history.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+  <body>
+    <page></page>
+    <script type="module">
+      import { TurboMini } from '../../src/turbomini.js';
+      const app = TurboMini('/tests/e2e/history.html');
+      app.template('default', '<a id="go" href="/tests/e2e/history.html/second" onclick="app.goto(\'/tests/e2e/history.html/second\'); return false;">Go</a><h1 id="home">Home</h1>');
+      app.template('second', '<h1 id="second">Second</h1>');
+      app.controller('default', () => ({}));
+      app.controller('second', () => ({}));
+      app.start();
+      window.app = app;
+    </script>
+  </body>
+</html>

--- a/tests/e2e/navigation.spec.mjs
+++ b/tests/e2e/navigation.spec.mjs
@@ -1,0 +1,24 @@
+// tests/e2e/navigation.spec.mjs
+import { test, expect } from '../fixtures/server.fixt.mjs';
+
+test('history navigation updates URL and supports back/forward', async ({ page, serverURL }) => {
+  await page.goto(`${serverURL}/tests/e2e/history.html`);
+  await page.click('#go');
+  await expect(page).toHaveURL(`${serverURL}/tests/e2e/history.html/second`);
+  await expect(page.locator('#second')).toHaveText('Second');
+  await page.goBack();
+  await expect(page.locator('#home')).toHaveText('Home');
+  await page.goForward();
+  await expect(page.locator('#second')).toHaveText('Second');
+});
+
+test('hash navigation updates hash and supports back/forward', async ({ page, serverURL }) => {
+  await page.goto(`${serverURL}/tests/e2e/hash.html`);
+  await page.click('#hash-link');
+  await expect(page).toHaveURL(`${serverURL}/tests/e2e/hash.html#/second`);
+  await expect(page.locator('#hash-second')).toHaveText('Second');
+  await page.goBack();
+  await expect(page.locator('#home')).toHaveText('Home');
+  await page.goForward();
+  await expect(page.locator('#hash-second')).toHaveText('Second');
+});

--- a/tests/e2e/templating.html
+++ b/tests/e2e/templating.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+  <body>
+    <page></page>
+    <script type="module">
+      import { TurboMini } from '../../src/turbomini.js';
+      const app = TurboMini('/tests/e2e/templating.html');
+      app.template('item', '<li class="item">{{this}}</li>');
+      app.template('default', '<ul id="list">{{#each items}}{{> item .}}{{/each}}</ul>');
+      app.controller('default', () => app.state);
+      app.state.items = ['a', 'b'];
+      app.start();
+      window.app = app;
+    </script>
+  </body>
+</html>

--- a/tests/e2e/templating.spec.mjs
+++ b/tests/e2e/templating.spec.mjs
@@ -1,0 +1,31 @@
+// tests/e2e/templating.spec.mjs
+import { test, expect } from '../fixtures/server.fixt.mjs';
+
+test('partials render and #each updates DOM', async ({ page, serverURL }) => {
+  await page.goto(`${serverURL}/tests/e2e/templating.html`);
+  const items = page.locator('#list li');
+  await expect(items).toHaveText(['a', 'b']);
+  await page.evaluate(() => {
+    window.app.state.items = [...window.app.state.items, 'c'];
+  });
+  await expect(items).toHaveText(['a', 'b', 'c']);
+});
+
+test('json helper feeds component and classList toggles classes', async ({ page, serverURL }) => {
+  await page.goto(`${serverURL}/tests/e2e/helpers.html`);
+  const raw = await page.locator('#comp').innerHTML();
+  const decoded = await page.evaluate((s) => {
+    const div = document.createElement('div');
+    div.innerHTML = s;
+    const once = div.textContent;
+    div.innerHTML = once;
+    return div.textContent;
+  }, raw);
+  expect(decoded).toBe('{"name":"Alice & Bob"}');
+  const box = page.locator('#box');
+  await expect(box).not.toHaveClass(/active/);
+  await page.evaluate(() => {
+    window.app.state.boxClasses = { ...window.app.state.boxClasses, active: true };
+  });
+  await expect(box).toHaveClass(/active/);
+});


### PR DESCRIPTION
## Summary
- expose example app for test access
- add navigation tests for history and hash modes
- cover partials, json helper, and classList reactivity

## Testing
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68c4e5c16ae883339e3e2d91a028b726