### PR TITLE
test: add scheduler strategy e2e tests

### DIFF
--- a/tests/e2e/scheduler.html
+++ b/tests/e2e/scheduler.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+  <body>
+    <page></page>
+    <script type="module">
+      import { TurboMini } from '../../src/turbomini.js';
+      const app = TurboMini('/tests/e2e/scheduler.html');
+      app.template('default', '<div id="count">{{count}}</div>');
+      app.controller('default', () => app.state);
+      app.state.count = 0;
+      app.start();
+      window.app = app;
+    </script>
+  </body>
+</html>

--- a/tests/e2e/scheduler.spec.mjs
+++ b/tests/e2e/scheduler.spec.mjs
@@ -1,0 +1,47 @@
+// tests/e2e/scheduler.spec.mjs
+import { test, expect } from '../fixtures/server.fixt.mjs';
+
+test('microtask coalescing batches renders', async ({ page, serverURL }) => {
+  await page.goto(`${serverURL}/tests/e2e/scheduler.html`);
+  const renders = await page.evaluate(async () => {
+    let count = 0;
+    const observer = new MutationObserver(() => count++);
+    observer.observe(document.querySelector('page'), {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    });
+    window.app.state.count = 1;
+    window.app.state.count = 2;
+    await new Promise((r) => setTimeout(r, 0));
+    observer.disconnect();
+    return count;
+  });
+  expect(renders).toBe(1);
+});
+
+test('raf mode batches multiple writes in one frame', async ({ page, serverURL }) => {
+  await page.goto(`${serverURL}/tests/e2e/scheduler.html`);
+  const renders = await page.evaluate(async () => {
+    window.app.setRenderStrategy({ mode: 'raf' });
+    let count = 0;
+    const observer = new MutationObserver(() => count++);
+    observer.observe(document.querySelector('page'), {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    });
+    await new Promise((resolve) => {
+      requestAnimationFrame(() => {
+        window.app.state.count = 3;
+        window.app.state.count = 4;
+        requestAnimationFrame(() => {
+          resolve();
+        });
+      });
+    });
+    observer.disconnect();
+    return count;
+  });
+  expect(renders).toBe(1);
+});


### PR DESCRIPTION
## Summary
- add HTML harness for scheduler strategy tests
- verify microtask scheduler batches renders
- verify RAF scheduler batches multiple writes in one frame

## Testing
- `npm test`
- `npm run test:e2e` *(fails: browserType.launch executable missing; attempted to install browsers but downloads/deps blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ec108eb883338d378bb249611e8b