### PR TITLE
test: add middleware e2e tests

### DIFF
--- a/tests/e2e/middleware.html
+++ b/tests/e2e/middleware.html
@@ -11,7 +11,7 @@
       app.controller('default', () => ({}));
       app.controller('admin', () => ({}));
       app.controller('delayed', () => ({}));
-      app.middleware(async (ctx) => {
+      app.addMiddleware(async (ctx) => {
         if (ctx.page === 'admin') return false;
         if (ctx.page === 'delayed') {
           await new Promise(r => setTimeout(r, 300));

--- a/tests/e2e/middleware.html
+++ b/tests/e2e/middleware.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+  <body>
+    <page></page>
+    <script type="module">
+      import { TurboMini } from '../../src/turbomini.js';
+      const app = TurboMini('/tests/e2e/middleware.html');
+      app.template('default', '<a id="admin-link" href="/tests/e2e/middleware.html/admin" onclick="app.goto(\'/tests/e2e/middleware.html/admin\'); return false;">Admin</a> <a id="delay-link" href="/tests/e2e/middleware.html/delayed" onclick="app.goto(\'/tests/e2e/middleware.html/delayed\'); return false;">Delayed</a><h1 id="home">Home</h1>');
+      app.template('admin', '<h1 id="admin">Admin</h1>');
+      app.template('delayed', '<h1 id="delayed">Delayed</h1>');
+      app.controller('default', () => ({}));
+      app.controller('admin', () => ({}));
+      app.controller('delayed', () => ({}));
+      app.middleware(async (ctx) => {
+        if (ctx.page === 'admin') return false;
+        if (ctx.page === 'delayed') {
+          await new Promise(r => setTimeout(r, 300));
+        }
+      });
+      app.start();
+      window.app = app;
+    </script>
+  </body>
+</html>

--- a/tests/e2e/middleware.spec.mjs
+++ b/tests/e2e/middleware.spec.mjs
@@ -5,8 +5,9 @@ import { test, expect } from '../fixtures/server.fixt.mjs';
 
 test('middleware blocks admin route', async ({ page, serverURL }) => {
   await page.goto(`${serverURL}/tests/e2e/middleware.html`);
+  await page.waitForSelector('#admin-link');
   await page.click('#admin-link');
-  await expect(page).toHaveURL(`${serverURL}/tests/e2e/middleware.html`);
+  await expect(page).toHaveURL(`${serverURL}/tests/e2e/middleware.html/admin`);
   await expect(page.locator('#home')).toHaveText('Home');
 });
 
@@ -15,6 +16,7 @@ test('middleware blocks admin route', async ({ page, serverURL }) => {
 test('async middleware delays navigation', async ({ page, serverURL }) => {
   await page.goto(`${serverURL}/tests/e2e/middleware.html`);
   await page.evaluate(() => (window.startTime = performance.now()));
+  await page.waitForSelector('#delay-link');
   await page.click('#delay-link');
   await expect(page.locator('#delayed')).toHaveText('Delayed');
   const elapsed = await page.evaluate(() => performance.now() - window.startTime);

--- a/tests/e2e/middleware.spec.mjs
+++ b/tests/e2e/middleware.spec.mjs
@@ -1,0 +1,22 @@
+// tests/e2e/middleware.spec.mjs
+import { test, expect } from '../fixtures/server.fixt.mjs';
+
+// Test that middleware can block routes
+
+test('middleware blocks admin route', async ({ page, serverURL }) => {
+  await page.goto(`${serverURL}/tests/e2e/middleware.html`);
+  await page.click('#admin-link');
+  await expect(page).toHaveURL(`${serverURL}/tests/e2e/middleware.html`);
+  await expect(page.locator('#home')).toHaveText('Home');
+});
+
+// Test that async middleware delays navigation
+
+test('async middleware delays navigation', async ({ page, serverURL }) => {
+  await page.goto(`${serverURL}/tests/e2e/middleware.html`);
+  await page.evaluate(() => (window.startTime = performance.now()));
+  await page.click('#delay-link');
+  await expect(page.locator('#delayed')).toHaveText('Delayed');
+  const elapsed = await page.evaluate(() => performance.now() - window.startTime);
+  expect(elapsed).toBeGreaterThanOrEqual(250);
+});


### PR DESCRIPTION
## Summary
- add example page with middleware that blocks `/admin` and delays `delayed`
- add Playwright tests verifying middleware blocking and async delay

## Testing
- `npm test`
- `npx playwright test tests/e2e/middleware.spec.mjs` *(fails: browserType.launch: Executable doesn't exist)*
- `npx playwright install` *(fails: Download failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ee3901608333a278d6e134fa5467