### PR TITLE
test: add fetchTemplates e2e coverage

### DIFF
--- a/components/x.html
+++ b/components/x.html
@@ -1,0 +1,1 @@
+<div id="x">fetched</div>

--- a/tests/e2e/fetch-templates.spec.mjs
+++ b/tests/e2e/fetch-templates.spec.mjs
@@ -1,0 +1,22 @@
+// tests/e2e/fetch-templates.spec.mjs
+import { test, expect } from '../fixtures/server.fixt.mjs';
+
+test('fetchTemplates renders fetched content', async ({ page, serverURL }) => {
+  await page.goto(`${serverURL}/tests/e2e/fetch.html`);
+  await page.evaluate(async () => {
+    await window.app.fetchTemplates(['x'], '/components/');
+    await window.app.start();
+  });
+  await expect(page.locator('#x')).toHaveText('fetched');
+});
+
+test('fetchTemplates surfaces errors for missing files', async ({ page, serverURL }) => {
+  await page.goto(`${serverURL}/tests/e2e/fetch.html`);
+  const message = await page.evaluate(() =>
+    window.app.fetchTemplates(['missing'], '/components/').then(
+      () => 'ok',
+      (e) => e.message,
+    ),
+  );
+  expect(message).toContain('Failed to fetch template "missing"');
+});

--- a/tests/e2e/fetch.html
+++ b/tests/e2e/fetch.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+  <body>
+    <page></page>
+    <script type="module">
+      import { TurboMini } from '../../src/turbomini.js';
+      const app = TurboMini('/tests/e2e/fetch.html');
+      app.template('default', '<div id="content">{{> x}}</div>');
+      window.app = app;
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add component template used for fetchTemplates e2e test
- add e2e page and spec covering successful fetch and missing file error

## Testing
- `npm test`
- `npm run test:e2e` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f2f23eec83338830c5109a990563