### PR TITLE
test: add controller lifecycle e2e

### DIFF
--- a/tests/e2e/lifecycle.html
+++ b/tests/e2e/lifecycle.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+  <body>
+    <page></page>
+    <script type="module">
+      import { TurboMini } from '../../src/turbomini.js';
+      const app = TurboMini('/tests/e2e/lifecycle.html');
+      window.unloadRan = false;
+      app.template('default', '<input id="focusme" /><a id="to-second" href="/tests/e2e/lifecycle.html/second" onclick="app.goto(\'/tests/e2e/lifecycle.html/second\'); return false;">Next</a>');
+      app.template('second', '<h1 id="status">{{status}}</h1>');
+      app.controller('default', () => ({
+        postLoad() {
+          document.getElementById('focusme').focus();
+        },
+        unload() {
+          window.unloadRan = true;
+        }
+      }));
+      app.controller('second', () => ({ status: String(window.unloadRan) }));
+      app.start();
+      window.app = app;
+    </script>
+  </body>
+</html>

--- a/tests/e2e/lifecycle.spec.mjs
+++ b/tests/e2e/lifecycle.spec.mjs
@@ -1,0 +1,9 @@
+// tests/e2e/lifecycle.spec.mjs
+import { test, expect } from '../fixtures/server.fixt.mjs';
+
+test('postLoad runs after render and unload runs before route change', async ({ page, serverURL }) => {
+  await page.goto(`${serverURL}/tests/e2e/lifecycle.html`);
+  await expect(page.locator('#focusme')).toBeFocused();
+  await page.click('#to-second');
+  await expect(page.locator('#status')).toHaveText('true');
+});


### PR DESCRIPTION
## Summary
- add lifecycle E2E page and test verifying `postLoad` and `unload`

## Testing
- `npm test`
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*
- `npx playwright install` *(fails: Download failed: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f5941d84833388cf289ae929c593