### PR TITLE
Add Web Components interoperability E2E tests

### DIFF
--- a/tests/e2e/web-components.html
+++ b/tests/e2e/web-components.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html>
+  <body>
+    <page></page>
+    <script type="module">
+      import { TurboMini } from '../../src/turbomini.js';
+      const app = TurboMini('/tests/e2e/web-components.html');
+      app.template('default', `
+        <my-el id="upgrade"></my-el>
+        <my-counter id="counter" count="{{count}}"></my-counter>
+        <json-comp id="json">
+          <script type="application/json">{"name":"Alice"}</script>
+        </json-comp>
+        <json-comp id="json-empty"></json-comp>
+      `);
+
+      class MyCounter extends HTMLElement {
+        static get observedAttributes() { return ['count']; }
+        connectedCallback() {
+          this.textContent = this.getAttribute('count');
+        }
+        attributeChangedCallback(name, oldValue, newValue) {
+          if (name === 'count') this.textContent = newValue;
+        }
+      }
+      customElements.define('my-counter', MyCounter);
+
+      class JsonComp extends HTMLElement {
+        connectedCallback() {
+          const script = this.querySelector('script[type="application/json"]');
+          if (script) {
+            const data = JSON.parse(script.textContent || '{}');
+            this.textContent = data.name;
+          } else {
+            this.textContent = 'no-data';
+          }
+        }
+      }
+      customElements.define('json-comp', JsonComp);
+
+      app.controller('default', () => ({ count: 0 }));
+      app.start();
+      window.app = app;
+    </script>
+  </body>
+</html>

--- a/tests/e2e/web-components.spec.mjs
+++ b/tests/e2e/web-components.spec.mjs
@@ -1,0 +1,30 @@
+// tests/e2e/web-components.spec.mjs
+import { test, expect } from '../fixtures/server.fixt.mjs';
+
+test('auto-upgrades custom elements after template insertion', async ({ page, serverURL }) => {
+  await page.goto(`${serverURL}/tests/e2e/web-components.html`);
+  const el = page.locator('#upgrade');
+  await expect(el).toHaveText('');
+  await page.evaluate(() => {
+    customElements.define('my-el', class extends HTMLElement {
+      connectedCallback() { this.textContent = 'upgraded'; }
+    });
+  });
+  await expect(el).toHaveText('upgraded');
+});
+
+test('attribute-driven re-render updates custom element', async ({ page, serverURL }) => {
+  await page.goto(`${serverURL}/tests/e2e/web-components.html`);
+  const counter = page.locator('#counter');
+  await expect(counter).toHaveText('0');
+  await page.evaluate(() => { window.app.state.count = 1; });
+  await expect(counter).toHaveText('1');
+});
+
+test('components parse optional JSON script child', async ({ page, serverURL }) => {
+  await page.goto(`${serverURL}/tests/e2e/web-components.html`);
+  const withData = page.locator('#json');
+  const withoutData = page.locator('#json-empty');
+  await expect(withData).toHaveText('Alice');
+  await expect(withoutData).toHaveText('no-data');
+});


### PR DESCRIPTION
## Summary
- cover auto-upgrading custom elements after template insertion
- verify re-rendering of components via attribute updates
- assert components can parse optional `<script type="application/json">` child

## Testing
- `npm test`
- `npm run test:e2e` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f7623d448333835a32a24d57b1cf