### PR TITLE
test: add robustness e2e tests

### DIFF
--- a/src/turbomini.js
+++ b/src/turbomini.js
@@ -507,7 +507,8 @@ const TurboMini = (basePath = "/") => {
     if (!hasDOM) return;
     try {
       const pageEl = $("page");
-      if (!pageEl) throw new Error("<page> element not found.");
+      if (!pageEl || !("innerHTML" in pageEl))
+        throw new Error("<page> element not found.");
       const nextHTML = $t(ctx.page, ctx.data);
       if (lastHTML == null) {
         pageEl.innerHTML = nextHTML;

--- a/tests/e2e/no-page.html
+++ b/tests/e2e/no-page.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+  <body>
+    <!-- no <page> element -->
+    <script type="module">
+      import { TurboMini } from '../../src/turbomini.js';
+      const app = TurboMini('/tests/e2e/no-page.html');
+      app.template('default', '<h1 id="hello">Hello</h1>');
+      window.app = app;
+    </script>
+  </body>
+</html>

--- a/tests/e2e/robustness.spec.mjs
+++ b/tests/e2e/robustness.spec.mjs
@@ -1,0 +1,44 @@
+// tests/e2e/robustness.spec.mjs
+import { test, expect } from '../fixtures/server.fixt.mjs';
+
+test('logs error when no <page> element exists and app remains usable', async ({ page, serverURL }) => {
+  await page.goto(`${serverURL}/tests/e2e/no-page.html`);
+  await page.evaluate(() => {
+    window.loggedErrors = [];
+    const orig = console.error;
+    console.error = (...args) => {
+      window.loggedErrors.push(args.map(a => String(a)).join(' '));
+      orig(...args);
+    };
+  });
+  await page.evaluate(() => window.app.start());
+  await expect.poll(() =>
+    page.evaluate(() =>
+      window.loggedErrors.some(t => t.includes('<page> element not found.')),
+    ),
+  ).toBe(true);
+
+  await page.evaluate(() => {
+    const el = document.createElement('page');
+    document.body.appendChild(el);
+    window.app.refreshNow();
+  });
+  await expect(page.locator('#hello')).toHaveText('Hello');
+});
+
+test('unknown template navigation logs error without freezing the app', async ({ page, serverURL }) => {
+  const errors = [];
+  page.on('console', msg => {
+    if (msg.type() === 'error') errors.push(msg.text());
+  });
+
+  await page.goto(`${serverURL}/tests/e2e/unknown-template.html`);
+  await expect(page.locator('#home')).toHaveText('Home');
+
+  await page.evaluate(() => window.app.goto('/missing'));
+  const hasError = errors.some(text => text.includes('Template "missing" not found.'));
+  expect(hasError).toBeTruthy();
+
+  await page.evaluate(() => window.app.goto('/'));
+  await expect(page.locator('#home')).toHaveText('Home');
+});

--- a/tests/e2e/unknown-template.html
+++ b/tests/e2e/unknown-template.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+  <body>
+    <page></page>
+    <script type="module">
+      import { TurboMini } from '../../src/turbomini.js';
+      const app = TurboMini('/tests/e2e/unknown-template.html');
+      app.template('default', '<h1 id="home">Home</h1>');
+      window.app = app;
+      app.start();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- ensure renderer throws when `<page>` element is missing
- add E2E tests for missing `<page>` element and unknown templates

## Testing
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68c5005c09b0833387a1355a34c9ea9c