### PR TITLE
Add demo examples and TypeScript consumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,11 +155,26 @@ document.addEventListener("click", (e) => {
 
 ### Run examples
 
-Start a local server and open [http://localhost:8055/examples/00-hello-world/](http://localhost:8055/examples/00-hello-world/):
+Start a local server and open any demo under `examples/`:
 
 ```bash
 npm run examples
 ```
+
+Examples available:
+
+- 00-hello-world
+- 01-counter
+- 02-router-basics-history
+- 03-router-basics-hash
+- 04-partials-and-each
+- 05-helpers-showcase
+- 06-components-grid
+- 07-middleware-guard
+- 08-fetch-templates
+- 09-params-and-controllers
+- 10-scheduler-modes
+- 11-typescript-consumer
 
 ### Run unit tests
 
@@ -174,7 +189,7 @@ npm test
 Run Playwright against the examples:
 
 ```bash
-npm run test:e2e
+npm run test:e2e # or npx playwright test
 ```
 
 ### Code quality

--- a/examples/01-counter/index.html
+++ b/examples/01-counter/index.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html>
+  <body>
+    <page></page>
+    <div>
+      <button id="inc">+</button>
+      <button id="dec">-</button>
+    </div>
+    <div>
+      <button class="mode" data-mode="microtask">microtask</button>
+      <button class="mode" data-mode="raf">raf</button>
+      <button class="mode" data-mode="debounce">debounce</button>
+    </div>
+    <script type="module">
+      import { TurboMini } from '../../src/turbomini.js';
+      const app = TurboMini('/examples/01-counter');
+      app.template('default', '<h1 id="count">{{count}}</h1>');
+      app.controller('default', () => app.state);
+      app.state.count = 0;
+      document.addEventListener('click', e => {
+        if (e.target.id === 'inc') app.state.count++;
+        if (e.target.id === 'dec') app.state.count--;
+        if (e.target.classList.contains('mode')) {
+          app.setRenderStrategy({ mode: e.target.dataset.mode });
+        }
+      });
+      app.start();
+      window.app = app;
+    </script>
+  </body>
+</html>

--- a/examples/01-counter/package.json
+++ b/examples/01-counter/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "01-counter",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "python -m http.server 8055",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": ""
+}

--- a/examples/02-router-basics-history/index.html
+++ b/examples/02-router-basics-history/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+  <body>
+    <nav>
+      <a id="home-link" href="/examples/02-router-basics-history/home" onclick="app.goto('/examples/02-router-basics-history/home'); return false;">Home</a>
+      <a id="about-link" href="/examples/02-router-basics-history/about" onclick="app.goto('/examples/02-router-basics-history/about'); return false;">About</a>
+    </nav>
+    <page></page>
+    <script type="module">
+      import { TurboMini } from '../../src/turbomini.js';
+      const app = TurboMini('/examples/02-router-basics-history');
+      app.template('home', '<h1 id="home">Home</h1>');
+      app.template('about', '<h1 id="about">About</h1>');
+      app.controller('home', () => ({}));
+      app.controller('about', () => ({}));
+      app.start();
+      window.app = app;
+    </script>
+  </body>
+</html>

--- a/examples/02-router-basics-history/package.json
+++ b/examples/02-router-basics-history/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "02-router-basics-history",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "python -m http.server 8055",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": ""
+}

--- a/examples/03-router-basics-hash/index.html
+++ b/examples/03-router-basics-hash/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+  <body>
+    <nav>
+      <a id="home-link" href="#/home" onclick="app.goto('/home'); return false;">Home</a>
+      <a id="about-link" href="#/about" onclick="app.goto('/about'); return false;">About</a>
+    </nav>
+    <page></page>
+    <script type="module">
+      import { TurboMini } from '../../src/turbomini.js';
+      const app = TurboMini('#');
+      app.template('home', '<h1 id="home">Home</h1>');
+      app.template('about', '<h1 id="about">About</h1>');
+      app.controller('home', () => ({}));
+      app.controller('about', () => ({}));
+      app.start();
+      window.app = app;
+    </script>
+  </body>
+</html>

--- a/examples/03-router-basics-hash/package.json
+++ b/examples/03-router-basics-hash/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "03-router-basics-hash",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "python -m http.server 8055",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": ""
+}

--- a/examples/04-partials-and-each/index.html
+++ b/examples/04-partials-and-each/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+  <body>
+    <page></page>
+    <button id="add">Add</button>
+    <button id="remove">Remove</button>
+    <script type="module">
+      import { TurboMini } from '../../src/turbomini.js';
+      const app = TurboMini('/examples/04-partials-and-each');
+      app.template('header', '<h1>Items</h1>');
+      app.template('item', '<li class="item">{{this}}</li>');
+      app.template('default', `{{> header}}\n{{#if items.length}}<ul id="list">{{#each items as item}}{{> item item}}{{/each}}</ul>{{else}}<p id="empty">No items</p>{{/if}}`);
+      app.controller('default', () => app.state);
+      app.state.items = [];
+      document.addEventListener('click', e => {
+        if (e.target.id === 'add') app.state.items.push('item ' + (app.state.items.length + 1));
+        if (e.target.id === 'remove') app.state.items.pop();
+      });
+      app.start();
+      window.app = app;
+    </script>
+  </body>
+</html>

--- a/examples/04-partials-and-each/package.json
+++ b/examples/04-partials-and-each/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "04-partials-and-each",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "python -m http.server 8055",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": ""
+}

--- a/examples/05-helpers-showcase/index.html
+++ b/examples/05-helpers-showcase/index.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html>
+  <body>
+    <page></page>
+    <script type="module">
+      import { TurboMini } from '../../src/turbomini.js';
+      const app = TurboMini('/examples/05-helpers-showcase');
+      app.registerHelper('uppercase', s => String(s).toUpperCase());
+      app.registerHelper('truncate', (s, len) => String(s).slice(0, Number(len)));
+      app.template('default', `
+        <div id="date">{{date now}}</div>
+        <div id="num">{{number value}}</div>
+        <div id="cls" class="{{classList cls}}">Classes</div>
+        <div id="up">{{uppercase msg}}</div>
+        <div id="tr">{{truncate msg 4}}</div>
+      `);
+      app.controller('default', () => ({
+        now: new Date().toISOString(),
+        value: 12345.67,
+        cls: { active: true, hidden: false },
+        msg: 'hello world'
+      }));
+      app.start();
+      window.app = app;
+    </script>
+  </body>
+</html>

--- a/examples/05-helpers-showcase/package.json
+++ b/examples/05-helpers-showcase/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "05-helpers-showcase",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "python -m http.server 8055",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": ""
+}

--- a/examples/06-components-grid/index.html
+++ b/examples/06-components-grid/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html>
+  <body>
+    <page></page>
+    <script type="module">
+      import { TurboMini } from '../../src/turbomini.js';
+      const app = TurboMini('/examples/06-components-grid');
+      class AnimationGridItem extends HTMLElement {
+        constructor() { super(); this.attachShadow({mode:'open'}); }
+        static get observedAttributes() { return ['data']; }
+        attributeChangedCallback() { this.render(); }
+        connectedCallback() { this.render(); }
+        render() {
+          const data = JSON.parse(this.getAttribute('data') || '{}');
+          this.shadowRoot.innerHTML = `<style>:host{display:block;border:1px solid #ccc;padding:4px;margin:2px}</style><div>${data.name}</div>`;
+        }
+      }
+      customElements.define('animation-grid-item', AnimationGridItem);
+      app.template('default', '<div id="grid">{{#each items as item}}<animation-grid-item data="{{{json item}}}"></animation-grid-item>{{/each}}</div>');
+      app.controller('default', () => app.state);
+      app.state.items = [{name:'A'},{name:'B'}];
+      app.start();
+      window.app = app;
+    </script>
+  </body>
+</html>

--- a/examples/06-components-grid/package.json
+++ b/examples/06-components-grid/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "06-components-grid",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "python -m http.server 8055",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": ""
+}

--- a/examples/07-middleware-guard/index.html
+++ b/examples/07-middleware-guard/index.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html>
+  <body>
+    <button id="login">Toggle Login</button>
+    <nav>
+      <a id="admin-link" href="/examples/07-middleware-guard/admin" onclick="app.goto('/examples/07-middleware-guard/admin'); return false;">Admin</a>
+    </nav>
+    <page></page>
+    <script type="module">
+      import { TurboMini } from '../../src/turbomini.js';
+      const app = TurboMini('/examples/07-middleware-guard');
+      app.template('default', '<h1 id="status">{{loggedIn ? "Logged In" : "Logged Out"}}</h1>');
+      app.template('admin', '<h1 id="admin">Admin</h1>');
+      app.controller('default', () => app.state);
+      app.controller('admin', () => ({}));
+      app.state.loggedIn = false;
+      app.addMiddleware(ctx => {
+        if (ctx.page === 'admin' && !app.state.loggedIn) return false;
+      });
+      document.getElementById('login').addEventListener('click', () => {
+        app.state.loggedIn = !app.state.loggedIn;
+      });
+      app.start();
+      window.app = app;
+    </script>
+  </body>
+</html>

--- a/examples/07-middleware-guard/package.json
+++ b/examples/07-middleware-guard/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "07-middleware-guard",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "python -m http.server 8055",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": ""
+}

--- a/examples/08-fetch-templates/footer.html
+++ b/examples/08-fetch-templates/footer.html
@@ -1,0 +1,1 @@
+<footer>Footer</footer>

--- a/examples/08-fetch-templates/header.html
+++ b/examples/08-fetch-templates/header.html
@@ -1,0 +1,1 @@
+<header>Header</header>

--- a/examples/08-fetch-templates/index.html
+++ b/examples/08-fetch-templates/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+  <body>
+    <div id="error"></div>
+    <page></page>
+    <script type="module">
+      import { TurboMini } from '../../src/turbomini.js';
+      const app = TurboMini('/examples/08-fetch-templates');
+      await app.fetchTemplates(['header','footer'], './');
+      try {
+        await app.fetchTemplates(['missing'], './');
+      } catch (e) {
+        document.getElementById('error').textContent = e.message;
+      }
+      app.template('default', '{{> header}}<main>Content</main>{{> footer}}');
+      app.start();
+      window.app = app;
+    </script>
+  </body>
+</html>

--- a/examples/08-fetch-templates/package.json
+++ b/examples/08-fetch-templates/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "08-fetch-templates",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "python -m http.server 8055",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": ""
+}

--- a/examples/09-params-and-controllers/index.html
+++ b/examples/09-params-and-controllers/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+  <body>
+    <nav>
+      <a href="/examples/09-params-and-controllers/users/42" onclick="app.goto('/examples/09-params-and-controllers/users/42'); return false;">User 42</a>
+    </nav>
+    <page></page>
+    <script type="module">
+      import { TurboMini } from '../../src/turbomini.js';
+      const app = TurboMini('/examples/09-params-and-controllers');
+      app.template('users', '<h1 id="user">User {{id}}</h1>');
+      app.template('default', '<h1 id="notfound">Not found</h1>');
+      app.controller('users', params => ({ id: params[0] }));
+      app.controller('default', () => ({}));
+      app.start();
+      window.app = app;
+    </script>
+  </body>
+</html>

--- a/examples/09-params-and-controllers/package.json
+++ b/examples/09-params-and-controllers/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "09-params-and-controllers",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "python -m http.server 8055",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": ""
+}

--- a/examples/10-scheduler-modes/index.html
+++ b/examples/10-scheduler-modes/index.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html>
+  <body>
+    <div>
+      <button class="mode" data-mode="microtask">microtask</button>
+      <button class="mode" data-mode="raf">raf</button>
+      <button class="mode" data-mode="throttle">throttle</button>
+      <button class="mode" data-mode="debounce">debounce</button>
+      <button class="mode" data-mode="idle">idle</button>
+    </div>
+    <div>FPS: <span id="fps">0</span></div>
+    <page></page>
+    <script type="module">
+      import { TurboMini } from '../../src/turbomini.js';
+      const app = TurboMini('/examples/10-scheduler-modes');
+      app.template('default', '<div id="tick">{{tick}}</div>');
+      app.controller('default', () => app.state);
+      app.state.tick = 0;
+      let frames = 0;
+      setInterval(() => { app.state.tick++; frames++; }, 0);
+      setInterval(() => { document.getElementById('fps').textContent = String(frames); frames = 0; }, 1000);
+      document.addEventListener('click', e => {
+        if (e.target.classList.contains('mode')) {
+          app.setRenderStrategy({ mode: e.target.dataset.mode, interval: 50 });
+        }
+      });
+      app.start();
+      window.app = app;
+    </script>
+  </body>
+</html>

--- a/examples/10-scheduler-modes/package.json
+++ b/examples/10-scheduler-modes/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "10-scheduler-modes",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "python -m http.server 8055",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": ""
+}

--- a/examples/11-typescript-consumer/dist/index.js
+++ b/examples/11-typescript-consumer/dist/index.js
@@ -1,0 +1,6 @@
+import { TurboMini } from 'turbomini';
+const app = TurboMini('/examples/11-typescript-consumer');
+app.template('default', '<h1>TS Consumer</h1>');
+app.controller('default', () => ({}));
+app.start();
+window.app = app;

--- a/examples/11-typescript-consumer/index.html
+++ b/examples/11-typescript-consumer/index.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+  <body>
+    <page></page>
+    <script type="module" src="./dist/index.js"></script>
+  </body>
+</html>

--- a/examples/11-typescript-consumer/index.ts
+++ b/examples/11-typescript-consumer/index.ts
@@ -1,0 +1,6 @@
+import { TurboMini } from 'turbomini';
+const app = TurboMini('/examples/11-typescript-consumer');
+app.template('default', '<h1>TS Consumer</h1>');
+app.controller('default', () => ({}));
+app.start();
+(window as any).app = app;

--- a/examples/11-typescript-consumer/package.json
+++ b/examples/11-typescript-consumer/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "11-typescript-consumer",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "start": "python -m http.server 8055"
+  }
+}

--- a/examples/11-typescript-consumer/tsconfig.json
+++ b/examples/11-typescript-consumer/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "outDir": "dist",
+    "strict": true
+  },
+  "include": ["index.ts"]
+}


### PR DESCRIPTION
## Summary
- add examples 01–10 demonstrating state, router, templating, helpers, components, middleware, fetchTemplates, params, and scheduler modes
- add TypeScript consumer example
- document example list and test commands in README

## Testing
- `npm test`
- `npm run test:e2e` *(fails: 18 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c503a5a8d4833391f33617f532f47d