### PR TITLE
Prefix base path in goto and auto-handle root-relative links

### DIFF
--- a/examples/02-router-basics-history/index.html
+++ b/examples/02-router-basics-history/index.html
@@ -2,8 +2,8 @@
 <html>
   <body>
     <nav>
-      <a id="home-link" href="/examples/02-router-basics-history/home" onclick="app.goto('/examples/02-router-basics-history/home'); return false;">Home</a>
-      <a id="about-link" href="/examples/02-router-basics-history/about" onclick="app.goto('/examples/02-router-basics-history/about'); return false;">About</a>
+      <a id="home-link" href="/home">Home</a>
+      <a id="about-link" href="/about">About</a>
     </nav>
     <page></page>
     <script type="module">

--- a/examples/03-router-basics-hash/index.html
+++ b/examples/03-router-basics-hash/index.html
@@ -2,8 +2,8 @@
 <html>
   <body>
     <nav>
-      <a id="home-link" href="#/home" onclick="app.goto('/home'); return false;">Home</a>
-      <a id="about-link" href="#/about" onclick="app.goto('/about'); return false;">About</a>
+      <a id="home-link" href="/home">Home</a>
+      <a id="about-link" href="/about">About</a>
     </nav>
     <page></page>
     <script type="module">

--- a/examples/07-middleware-guard/index.html
+++ b/examples/07-middleware-guard/index.html
@@ -3,7 +3,7 @@
   <body>
     <button id="login">Toggle Login</button>
     <nav>
-      <a id="admin-link" href="/examples/07-middleware-guard/admin" onclick="app.goto('/examples/07-middleware-guard/admin'); return false;">Admin</a>
+      <a id="admin-link" href="/admin">Admin</a>
     </nav>
     <page></page>
     <script type="module">

--- a/examples/09-params-and-controllers/index.html
+++ b/examples/09-params-and-controllers/index.html
@@ -2,7 +2,7 @@
 <html>
   <body>
     <nav>
-      <a href="/examples/09-params-and-controllers/users/42" onclick="app.goto('/examples/09-params-and-controllers/users/42'); return false;">User 42</a>
+      <a href="/users/42">User 42</a>
     </nav>
     <page></page>
     <script type="module">

--- a/src/turbomini.js
+++ b/src/turbomini.js
@@ -605,13 +605,24 @@ const TurboMini = (basePath = "/") => {
       if (location.hash !== "#" + route) location.hash = route;
       else start();
     } else {
-      if (location.pathname !== route) history.pushState({}, "", route);
+      const fullRoute = basePath === "/" ? route : basePath + route;
+      if (location.pathname !== fullRoute) history.pushState({}, "", fullRoute);
       start();
     }
   };
 
   on("popstate", start);
   on("hashchange", start);
+  if (hasDOM)
+    on("click", (e) => {
+      const a = e.target.closest ? e.target.closest("a") : null;
+      if (!a) return;
+      const href = a.getAttribute("href");
+      if (!href || !href.startsWith("/") || (a.target && a.target !== "_self"))
+        return;
+      e.preventDefault();
+      goto(href);
+    });
 
   // ---- Controllers & middleware --------------------------------------------
   /**

--- a/tests/e2e/hash.html
+++ b/tests/e2e/hash.html
@@ -5,7 +5,7 @@
     <script type="module">
       import { TurboMini } from '../../src/turbomini.js';
       const app = TurboMini('#');
-      app.template('default', '<a id="hash-link" href="#/second" onclick="app.goto(\'/second\'); return false;">Go</a><h1 id="home">Home</h1>');
+      app.template('default', '<a id="hash-link" href="/second">Go</a><h1 id="home">Home</h1>');
       app.template('second', '<h1 id="hash-second">Second</h1>');
       app.controller('default', () => ({}));
       app.controller('second', () => ({}));

--- a/tests/e2e/history.html
+++ b/tests/e2e/history.html
@@ -5,7 +5,7 @@
     <script type="module">
       import { TurboMini } from '../../src/turbomini.js';
       const app = TurboMini('/tests/e2e/history.html');
-      app.template('default', '<a id="go" href="/tests/e2e/history.html/second" onclick="app.goto(\'/tests/e2e/history.html/second\'); return false;">Go</a><h1 id="home">Home</h1>');
+      app.template('default', '<a id="go" href="/second">Go</a><h1 id="home">Home</h1>');
       app.template('second', '<h1 id="second">Second</h1>');
       app.controller('default', () => ({}));
       app.controller('second', () => ({}));

--- a/tests/e2e/lifecycle.html
+++ b/tests/e2e/lifecycle.html
@@ -6,7 +6,7 @@
       import { TurboMini } from '../../src/turbomini.js';
       const app = TurboMini('/tests/e2e/lifecycle.html');
       window.unloadRan = false;
-      app.template('default', '<input id="focusme" /><a id="to-second" href="/tests/e2e/lifecycle.html/second" onclick="app.goto(\'/tests/e2e/lifecycle.html/second\'); return false;">Next</a>');
+      app.template('default', '<input id="focusme" /><a id="to-second" href="/second">Next</a>');
       app.template('second', '<h1 id="status">{{status}}</h1>');
       app.controller('default', () => ({
         postLoad() {

--- a/tests/e2e/middleware.html
+++ b/tests/e2e/middleware.html
@@ -5,7 +5,7 @@
     <script type="module">
       import { TurboMini } from '../../src/turbomini.js';
       const app = TurboMini('/tests/e2e/middleware.html');
-      app.template('default', '<a id="admin-link" href="/tests/e2e/middleware.html/admin" onclick="app.goto(\'/tests/e2e/middleware.html/admin\'); return false;">Admin</a> <a id="delay-link" href="/tests/e2e/middleware.html/delayed" onclick="app.goto(\'/tests/e2e/middleware.html/delayed\'); return false;">Delayed</a><h1 id="home">Home</h1>');
+      app.template('default', '<a id="admin-link" href="/admin">Admin</a> <a id="delay-link" href="/delayed">Delayed</a><h1 id="home">Home</h1>');
       app.template('admin', '<h1 id="admin">Admin</h1>');
       app.template('delayed', '<h1 id="delayed">Delayed</h1>');
       app.controller('default', () => ({}));

--- a/tests/unit/router.test.js
+++ b/tests/unit/router.test.js
@@ -52,6 +52,23 @@ test('goto() pushes state and invokes start', async () => {
   assert.equal(controllerCalls, 1);
 });
 
+test('goto() prefixes basePath for history mode', async () => {
+  const pushes = [];
+  globalThis.location = { pathname: '/app', hash: '' };
+  globalThis.history = {
+    pushState: (s, t, p) => {
+      pushes.push(p);
+      globalThis.location.pathname = p;
+    },
+  };
+  const app = TurboMini('/app');
+  app.controller('foo', () => {});
+  app.goto('/foo');
+  await tick();
+  assert.deepEqual(pushes, ['/app/foo']);
+  assert.equal(app.context.page, 'foo');
+});
+
 test('middleware executes in order', async () => {
   globalThis.location = { pathname: '/foo', hash: '' };
   globalThis.history = { pushState() {} };

--- a/types/turbomini.d.ts
+++ b/types/turbomini.d.ts
@@ -62,7 +62,7 @@ export type TurboMiniApp = any;
 /** @property {ComponentDefiner} defineComponent */
 /** @property {ControllerRegistrar} controller */
 /** @property {() => Promise<void>} start */
-/** @property {(route: string) => void} goto */
+/** @property {(route: string) => void} goto Navigate to a route; in history mode, routes are prefixed with basePath. */
 /** @property {() => void} refresh */
 /** @property {() => void} refreshNow */
 /** @property {(opts?: RenderStrategyOptions) => void} setRenderStrategy */
@@ -84,6 +84,7 @@ export type TurboMiniApp = any;
 /**
  * Create a TurboMini application.
  * @param {string} [basePath="/"] "/" for history mode, "#" for hash routing, or a sub-path like "/app".
+ * Routes passed to {@link TurboMiniApp.goto} and root-relative anchor clicks are resolved relative to this base path.
  * @returns {TurboMiniApp}
  */
 export function TurboMini(basePath?: string): TurboMiniApp;


### PR DESCRIPTION
## Summary
- prefix non-root basePath to routes in goto()
- intercept root-relative links with a global click handler
- document basePath-aware navigation in type definitions
- update examples, tests, and router unit tests to use base-path-relative links

## Testing
- `npm test`
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist at ...; attempted `npx playwright install` but downloads were forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f9196b60833383d4431028f9bf85