### PR TITLE
Remove scheduled state proxy

### DIFF
--- a/src/turbomini.js
+++ b/src/turbomini.js
@@ -55,7 +55,6 @@
 /** @property {() => void} refresh */
 /** @property {() => void} refreshNow */
 /** @property {(opts?: RenderStrategyOptions) => void} setRenderStrategy */
-/** @property {Record<string, any>} state */
 /** @property {Context} context */
 /** @property {TemplateFetcher} fetchTemplates */
 /** @property {TemplateFetcher} prefetchTemplates */
@@ -536,18 +535,6 @@ const TurboMini = (basePath = "/") => {
    */
   const refresh = () => invalidate(); // scheduled (back-compat name)
 
-  // ---- State (scheduled) ----------------------------------------------------
-  const state = new Proxy(
-    {},
-    {
-      set(target, prop, value) {
-        target[prop] = value;
-        invalidate(); // schedule a render based on strategy
-        return true;
-      },
-    },
-  );
-
   // ---- Router ---------------------------------------------------------------
   const normalizeRoute = () => {
     let raw = useHash
@@ -693,7 +680,6 @@ const TurboMini = (basePath = "/") => {
     prefetchTemplates,
 
     // state & context
-    state,
     context: ctx,
 
     // utilities

--- a/tests/unit/core.test.js
+++ b/tests/unit/core.test.js
@@ -15,15 +15,3 @@ test('template: missing template throws', () => {
   assert.throws(() => app.$t('nope', {}), /Template "nope" not found/);
 });
 
-test('state writes coalesce (microtask)', async () => {
-  const app = TurboMini('/');
-  let renders = 0;
-  app.refreshNow = () => { renders++; };  // count actual renders
-
-  app.state.a = 1;
-  app.state.b = 2;
-  app.state.c = 3;
-
-  await Promise.resolve();  // flush microtask debounce
-  assert.equal(renders, 1);
-});

--- a/types/turbomini.d.ts
+++ b/types/turbomini.d.ts
@@ -62,11 +62,10 @@ export type TurboMiniApp = any;
 /** @property {ComponentDefiner} defineComponent */
 /** @property {ControllerRegistrar} controller */
 /** @property {() => Promise<void>} start */
-/** @property {(route: string) => void} goto Navigate to a route; in history mode, routes are prefixed with basePath. */
+/** @property {(route: string) => void} goto */
 /** @property {() => void} refresh */
 /** @property {() => void} refreshNow */
 /** @property {(opts?: RenderStrategyOptions) => void} setRenderStrategy */
-/** @property {Record<string, any>} state */
 /** @property {Context} context */
 /** @property {TemplateFetcher} fetchTemplates */
 /** @property {TemplateFetcher} prefetchTemplates */
@@ -84,7 +83,6 @@ export type TurboMiniApp = any;
 /**
  * Create a TurboMini application.
  * @param {string} [basePath="/"] "/" for history mode, "#" for hash routing, or a sub-path like "/app".
- * Routes passed to {@link TurboMiniApp.goto} and root-relative anchor clicks are resolved relative to this base path.
  * @returns {TurboMiniApp}
  */
 export function TurboMini(basePath?: string): TurboMiniApp;


### PR DESCRIPTION
## Summary
- drop reactive state proxy and its public property
- clean up types and outdated unit test

## Testing
- `npm test`
- `npm run lint`
- `node_modules/typescript/bin/tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68c6fb3c96588333b79b72560dc0da65