### PR TITLE
Use local store instead of app.state in e2e tests

### DIFF
--- a/tests/e2e/helpers.html
+++ b/tests/e2e/helpers.html
@@ -5,16 +5,16 @@
     <script type="module">
       import { TurboMini } from '../../src/turbomini.js';
       const app = TurboMini('/tests/e2e/helpers.html');
+      const store = { user: { name: 'Alice & Bob' }, boxClasses: { active: false } };
 
       app.template('default', `
         <div id="comp">{{json user}}</div>
         <div id="box" class="{{classList boxClasses}}">Box</div>
       `);
-      app.controller('default', () => app.state);
-      app.state.user = { name: 'Alice & Bob' };
-      app.state.boxClasses = { active: false };
+      app.controller('default', () => store);
       app.start();
       window.app = app;
+      window.store = store;
     </script>
   </body>
 </html>

--- a/tests/e2e/scheduler.html
+++ b/tests/e2e/scheduler.html
@@ -5,11 +5,12 @@
     <script type="module">
       import { TurboMini } from '../../src/turbomini.js';
       const app = TurboMini('/tests/e2e/scheduler.html');
+      const store = { count: 0 };
       app.template('default', '<div id="count">{{count}}</div>');
-      app.controller('default', () => app.state);
-      app.state.count = 0;
+      app.controller('default', () => store);
       app.start();
       window.app = app;
+      window.store = store;
     </script>
   </body>
 </html>

--- a/tests/e2e/scheduler.spec.mjs
+++ b/tests/e2e/scheduler.spec.mjs
@@ -11,8 +11,10 @@ test('microtask coalescing batches renders', async ({ page, serverURL }) => {
       subtree: true,
       characterData: true,
     });
-    window.app.state.count = 1;
-    window.app.state.count = 2;
+    window.store.count = 1;
+    window.app.invalidate();
+    window.store.count = 2;
+    window.app.invalidate();
     await new Promise((r) => setTimeout(r, 0));
     observer.disconnect();
     return count;
@@ -33,8 +35,10 @@ test('raf mode batches multiple writes in one frame', async ({ page, serverURL }
     });
     await new Promise((resolve) => {
       requestAnimationFrame(() => {
-        window.app.state.count = 3;
-        window.app.state.count = 4;
+        window.store.count = 3;
+        window.app.invalidate();
+        window.store.count = 4;
+        window.app.invalidate();
         requestAnimationFrame(() => {
           resolve();
         });

--- a/tests/e2e/templating.html
+++ b/tests/e2e/templating.html
@@ -5,12 +5,13 @@
     <script type="module">
       import { TurboMini } from '../../src/turbomini.js';
       const app = TurboMini('/tests/e2e/templating.html');
+      const store = { items: ['a', 'b'] };
       app.template('item', '<li class="item">{{this}}</li>');
       app.template('default', '<ul id="list">{{#each items}}{{> item .}}{{/each}}</ul>');
-      app.controller('default', () => app.state);
-      app.state.items = ['a', 'b'];
+      app.controller('default', () => store);
       app.start();
       window.app = app;
+      window.store = store;
     </script>
   </body>
 </html>

--- a/tests/e2e/templating.spec.mjs
+++ b/tests/e2e/templating.spec.mjs
@@ -6,7 +6,8 @@ test('partials render and #each updates DOM', async ({ page, serverURL }) => {
   const items = page.locator('#list li');
   await expect(items).toHaveText(['a', 'b']);
   await page.evaluate(() => {
-    window.app.state.items = [...window.app.state.items, 'c'];
+    window.store.items = [...window.store.items, 'c'];
+    window.app.invalidate();
   });
   await expect(items).toHaveText(['a', 'b', 'c']);
 });
@@ -25,7 +26,8 @@ test('json helper feeds component and classList toggles classes', async ({ page,
   const box = page.locator('#box');
   await expect(box).not.toHaveClass(/active/);
   await page.evaluate(() => {
-    window.app.state.boxClasses = { ...window.app.state.boxClasses, active: true };
+    window.store.boxClasses = { ...window.store.boxClasses, active: true };
+    window.app.invalidate();
   });
   await expect(box).toHaveClass(/active/);
 });

--- a/tests/e2e/web-components.html
+++ b/tests/e2e/web-components.html
@@ -5,6 +5,7 @@
     <script type="module">
       import { TurboMini } from '../../src/turbomini.js';
       const app = TurboMini('/tests/e2e/web-components.html');
+      const store = { count: 0 };
       app.template('default', `
         <my-el id="upgrade"></my-el>
         <my-counter id="counter" count="{{count}}"></my-counter>
@@ -38,10 +39,10 @@
       }
       customElements.define('json-comp', JsonComp);
 
-      app.state.count = 0;
-      app.controller('default', () => app.state);
+      app.controller('default', () => store);
       app.start();
       window.app = app;
+      window.store = store;
     </script>
   </body>
 </html>

--- a/tests/e2e/web-components.spec.mjs
+++ b/tests/e2e/web-components.spec.mjs
@@ -17,7 +17,10 @@ test('attribute-driven re-render updates custom element', async ({ page, serverU
   await page.goto(`${serverURL}/tests/e2e/web-components.html`);
   const counter = page.locator('#counter');
   await expect(counter).toHaveText('0');
-  await page.evaluate(() => { window.app.state.count = 1; });
+  await page.evaluate(() => {
+    window.store.count = 1;
+    window.app.invalidate();
+  });
   await expect(counter).toHaveText('1');
 });
 


### PR DESCRIPTION
## Summary
- use scoped `store` objects in e2e HTML fixtures
- mutate `store` with `app.invalidate()` in e2e specs

## Testing
- `npm test`
- `npm run test:e2e` *(fails: 18 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6fde8796c833380bc25c56a7610e7