### PR TITLE
Use store objects in examples

### DIFF
--- a/examples/01-counter/index.html
+++ b/examples/01-counter/index.html
@@ -15,11 +15,11 @@
       import { TurboMini } from '../../src/turbomini.js';
       const app = TurboMini('/examples/01-counter');
       app.template('default', '<h1 id="count">{{count}}</h1>');
-      app.controller('default', () => app.state);
-      app.state.count = 0;
+      const store = { count: 0 };
+      app.controller('default', () => store);
       document.addEventListener('click', e => {
-        if (e.target.id === 'inc') app.state.count++;
-        if (e.target.id === 'dec') app.state.count--;
+        if (e.target.id === 'inc') { store.count++; app.invalidate(); }
+        if (e.target.id === 'dec') { store.count--; app.invalidate(); }
         if (e.target.classList.contains('mode')) {
           app.setRenderStrategy({ mode: e.target.dataset.mode });
         }

--- a/examples/04-partials-and-each/index.html
+++ b/examples/04-partials-and-each/index.html
@@ -10,11 +10,11 @@
       app.template('header', '<h1>Items</h1>');
       app.template('item', '<li class="item">{{this}}</li>');
       app.template('default', `{{> header}}\n{{#if items.length}}<ul id="list">{{#each items as item}}{{> item item}}{{/each}}</ul>{{else}}<p id="empty">No items</p>{{/if}}`);
-      app.controller('default', () => app.state);
-      app.state.items = [];
+      const store = { items: [] };
+      app.controller('default', () => store);
       document.addEventListener('click', e => {
-        if (e.target.id === 'add') app.state.items.push('item ' + (app.state.items.length + 1));
-        if (e.target.id === 'remove') app.state.items.pop();
+        if (e.target.id === 'add') { store.items.push('item ' + (store.items.length + 1)); app.invalidate(); }
+        if (e.target.id === 'remove') { store.items.pop(); app.invalidate(); }
       });
       app.start();
       window.app = app;

--- a/examples/06-components-grid/index.html
+++ b/examples/06-components-grid/index.html
@@ -17,8 +17,8 @@
       }
       customElements.define('animation-grid-item', AnimationGridItem);
       app.template('default', '<div id="grid">{{#each items as item}}<animation-grid-item data="{{{json item}}}"></animation-grid-item>{{/each}}</div>');
-      app.controller('default', () => app.state);
-      app.state.items = [{name:'A'},{name:'B'}];
+      const store = { items: [{name:'A'},{name:'B'}] };
+      app.controller('default', () => store);
       app.start();
       window.app = app;
     </script>

--- a/examples/07-middleware-guard/index.html
+++ b/examples/07-middleware-guard/index.html
@@ -11,14 +11,15 @@
       const app = TurboMini('/examples/07-middleware-guard');
       app.template('default', '<h1 id="status">{{loggedIn ? "Logged In" : "Logged Out"}}</h1>');
       app.template('admin', '<h1 id="admin">Admin</h1>');
-      app.controller('default', () => app.state);
-      app.controller('admin', () => ({}));
-      app.state.loggedIn = false;
+      const store = { loggedIn: false };
+      app.controller('default', () => store);
+      app.controller('admin', () => store);
       app.addMiddleware(ctx => {
-        if (ctx.page === 'admin' && !app.state.loggedIn) return false;
+        if (ctx.page === 'admin' && !store.loggedIn) return false;
       });
       document.getElementById('login').addEventListener('click', () => {
-        app.state.loggedIn = !app.state.loggedIn;
+        store.loggedIn = !store.loggedIn;
+        app.invalidate();
       });
       app.start();
       window.app = app;

--- a/examples/10-scheduler-modes/index.html
+++ b/examples/10-scheduler-modes/index.html
@@ -14,10 +14,10 @@
       import { TurboMini } from '../../src/turbomini.js';
       const app = TurboMini('/examples/10-scheduler-modes');
       app.template('default', '<div id="tick">{{tick}}</div>');
-      app.controller('default', () => app.state);
-      app.state.tick = 0;
+      const store = { tick: 0 };
+      app.controller('default', () => store);
       let frames = 0;
-      setInterval(() => { app.state.tick++; frames++; }, 0);
+      setInterval(() => { store.tick++; app.invalidate(); frames++; }, 0);
       setInterval(() => { document.getElementById('fps').textContent = String(frames); frames = 0; }, 1000);
       document.addEventListener('click', e => {
         if (e.target.classList.contains('mode')) {


### PR DESCRIPTION
## Summary
- migrate examples to use store objects instead of `app.state`
- update controllers to return the store and trigger renders via `app.invalidate`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6ff36cce4833383422d3778472a37