### PR TITLE
docs: remove app.state references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # TurboMini
 
-A tiny, dependency-free SPA micro-framework.  
-Designed for small projects that want routing, templates, and state without pulling in React/Vue/Angular.
+A tiny, dependency-free SPA micro-framework.
+Designed for small projects that want routing, templates, and simple user-managed stores without pulling in React/Vue/Angular.
 
 ---
 
@@ -10,7 +10,7 @@ Designed for small projects that want routing, templates, and state without pull
 - **Routing** – history API or hash-based.
 - **Templates** – minimal mustache-style with `{{var}}`.
 - **Controllers** – per-page data providers.
-- **State** – reactive proxy object (auto-refresh).
+- **Stores** – manage your own objects and call `app.invalidate()` on changes.
 - **Middleware** – run before route changes.
 - **Components** – combine templates + controllers.
 - **Tiny footprint** – one file, no deps.
@@ -74,17 +74,14 @@ Programmatically change routes.
 app.goto("/profile");
 ```
 
-### `app.state`
+### `app.invalidate()` / `app.refreshNow()`
 
-Reactive object. Any writes trigger a re-render.
+Schedule or force a render.
 
 ```js
-app.state.count = 1;
+store.count++;
+app.invalidate(); // or app.refreshNow();
 ```
-
-### `app.refresh()`
-
-Force a re-render manually.
 
 ### `app.addMiddleware(fn)`
 
@@ -133,6 +130,7 @@ console.log(app.inspect());
 
 ```js
 const app = TurboMini("/");
+const store = { count: 0 };
 app.template(
   "counter",
   `
@@ -140,12 +138,15 @@ app.template(
   <div>Count: {{count}}</div>
 `,
 );
-app.controller("counter", () => app.state);
+app.controller("counter", () => store);
 
 app.start();
 
 document.addEventListener("click", (e) => {
-  if (e.target.id === "inc") app.state.count++;
+  if (e.target.id === "inc") {
+    store.count++;
+    app.invalidate(); // or app.refreshNow();
+  }
 });
 ```
 
@@ -208,4 +209,4 @@ npm run lint
 - Routes are based on the first path segment (`/home`, `/about`).
 - The root path `/` (or `#/` in hash mode) resolves to the `default` template/controller.
 - Use hash routing (`TurboMini('#')`) for static hosting.
-- State writes are batched, but you can always call `app.refresh()` explicitly.
+- Manage your own store; mutate it and call `app.invalidate()` (or `app.refreshNow()` for an immediate render).

--- a/docs/turbomini.js
+++ b/docs/turbomini.js
@@ -52,10 +52,9 @@
 /** @property {ControllerRegistrar} controller */
 /** @property {() => Promise<void>} start */
 /** @property {(route: string) => void} goto */
-/** @property {() => void} refresh */
 /** @property {() => void} refreshNow */
+/** @property {() => void} invalidate */
 /** @property {(opts?: RenderStrategyOptions) => void} setRenderStrategy */
-/** @property {Record<string, any>} state */
 /** @property {Context} context */
 /** @property {TemplateFetcher} fetchTemplates */
 /** @property {TemplateFetcher} prefetchTemplates */
@@ -69,7 +68,6 @@
 /** @property {(el: Element, type: string, handler: EventListener, opts?: any) => (() => void)} listen */
 /** @property {(fn: (app: TurboMiniApp) => any) => Promise<TurboMiniApp>} run */
 /** @property {(e: unknown) => void} errorHandler */
-/** @property {() => void} invalidate */
 
 /**
  * Create a TurboMini application.
@@ -535,7 +533,8 @@ const TurboMini = (basePath = "/") => {
    */
   const refresh = () => invalidate(); // scheduled (back-compat name)
 
-  // ---- State (scheduled) ----------------------------------------------------
+  // ---- Legacy state (scheduled) ---------------------------------------------
+  // Prefer managing your own store and calling app.invalidate()/app.refreshNow().
   const state = new Proxy(
     {},
     {
@@ -680,7 +679,7 @@ const TurboMini = (basePath = "/") => {
     fetchTemplates,
     prefetchTemplates,
 
-    // state & context
+    // legacy state & context (manage your own store)
     state,
     context: ctx,
 

--- a/types/turbomini.d.ts
+++ b/types/turbomini.d.ts
@@ -63,8 +63,8 @@ export type TurboMiniApp = any;
 /** @property {ControllerRegistrar} controller */
 /** @property {() => Promise<void>} start */
 /** @property {(route: string) => void} goto */
-/** @property {() => void} refresh */
 /** @property {() => void} refreshNow */
+/** @property {() => void} invalidate */
 /** @property {(opts?: RenderStrategyOptions) => void} setRenderStrategy */
 /** @property {Context} context */
 /** @property {TemplateFetcher} fetchTemplates */
@@ -79,7 +79,6 @@ export type TurboMiniApp = any;
 /** @property {(el: Element, type: string, handler: EventListener, opts?: any) => (() => void)} listen */
 /** @property {(fn: (app: TurboMiniApp) => any) => Promise<TurboMiniApp>} run */
 /** @property {(e: unknown) => void} errorHandler */
-/** @property {() => void} invalidate */
 /**
  * Create a TurboMini application.
  * @param {string} [basePath="/"] "/" for history mode, "#" for hash routing, or a sub-path like "/app".


### PR DESCRIPTION
## Summary
- drop app.state section from README
- show local stores with app.invalidate/app.refreshNow
- clarify docs and types to favor user-managed stores

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c70053255883338abd582211b5bb8e