### PR TITLE
test: assert app has no state property

### DIFF
--- a/tests/unit/api.test.js
+++ b/tests/unit/api.test.js
@@ -2,6 +2,11 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { TurboMini } from '../../src/turbomini.js';
 
+test('app has no state property', () => {
+  const app = TurboMini('/');
+  assert.equal('state' in app, false);
+});
+
 test('inspect lists registered routes, templates, helpers and default mode', () => {
   const app = TurboMini('/');
   app.controller('home', () => {});


### PR DESCRIPTION
## Summary
- add unit test ensuring TurboMini instances do not expose a `state` property

## Testing
- `node_modules/typescript/bin/tsc -p tsconfig.json`
- `rg 'app.state'`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c701f6b76083338d86255e56ef95cb