### PR TITLE
Improve CLI ergonomics and docs

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@2.3.1/schema.json",
+  "changelog": "@changesets/cli/changelog",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "public",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch"
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,58 @@
 name: ci
 on:
   push:
-    branches: [main] # only when code actually lands
+    branches: [main]
   pull_request:
-    branches: [main] # PRs into main
+    branches: [main]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run lint
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run build
+
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: { node-version: 20 }
+        with:
+          node-version: 20
       - run: npm ci
       - run: npm test
       - run: npx playwright install --with-deps
       - run: npm run test:e2e
+
+  publish:
+    needs: [lint, build, test]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm run build
+      - uses: changesets/action@v1
+        with:
+          publish: npm run release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ Available commands:
 | `turbomini init [dir]` | Scaffold a new project (Vite config, starter app, base theme). |
 | `turbomini theme init [dir]` | Copy base tokens (`tokens.css`, `tokens.dark.css`, `theme.css`) into `src/styles/turbomini`. |
 | `turbomini theme create <name> [--dir .]` | Generate a new theme override folder with editable JSON + CSS. |
-| `turbomini add <component> [--mode copy|wc]` | Install a component recipe (`copy`) or add the web component package (`wc`). |
+| `turbomini add <component> [--mode copy|wc]` | Install a component recipe (`copy`, default) or add the web component package (`wc`). |
 | `turbomini update <component>` | Refresh local component recipes from the monorepo (copy mode). |
+| `turbomini doctor [dir]` | Check for drift between your tokens/packages and the workspace defaults. |
 | All commands support `--dry-run` | Preview file writes with diffs before mutating disk. |
 
 Example usage:
@@ -94,12 +95,16 @@ The first component, `<tm-button>`, demonstrates the TurboMini web component pat
 - Custom events: emits `tm-press` with `{ originalEvent, value }` when activated.
 - Accessible by default (uses native `<button>`, focus ring from tokens, `aria-busy` when loading).
 - Uses only CSS variables (`--tm-button-*`) so themes can override colors, borders, and spacing.
+- Token + parts reference: see [`packages/wc/tm-button/README.md`](packages/wc/tm-button/README.md).
+- Event naming follows the [`tm-*` convention](docs/web-components/events.md).
 
 Install via the CLI:
 
 ```bash
 # Copy recipe into src/components
 turbomini add tm-button --mode copy
+
+# The CLI defaults to copy mode and will remind you how to switch to --mode wc.
 
 # or consume the published web component package
 turbomini add tm-button --mode wc
@@ -123,6 +128,13 @@ Starter projects and the previous examples now live under `templates/`:
 
 - `templates/starter/spa` – Vite starter used by the CLI `init` command.
 - `templates/examples/*` – historical examples preserved for reference.
+
+The starter includes a responsive feature grid that demonstrates container queries (`src/styles/app.css`).
+
+## Server rendering & islands
+
+TurboMini plays nicely with server rendering or island architectures. See [`docs/ssr.md`](docs/ssr.md) for strategies to
+defer web component registration, hydrate progressively, and provide light DOM fallbacks while custom elements load.
 
 ## Development
 

--- a/docs/ssr.md
+++ b/docs/ssr.md
@@ -1,0 +1,50 @@
+# Server rendering & island architectures
+
+TurboMini is small enough to render entire pages on the server or hydrate individual islands on demand. The runtime ships zero
+assumptions about the rendering environment—everything is declarative and opt-in.
+
+## Defer web component registration
+
+When streaming HTML from the server you can defer custom-element registration until the browser takes over. Every TurboMini web
+component exports a `define*` helper in addition to side-effectful registration. Call it when the island mounts:
+
+```js
+import { defineTmButton } from '@turbomini/wc-button';
+
+if (typeof window !== 'undefined') {
+  defineTmButton();
+}
+```
+
+This keeps SSR-friendly hydration fast while still allowing eager registration in fully client-side builds via
+`import '@turbomini/wc-button';`.
+
+## Provide light DOM fallbacks
+
+Because TurboMini components use slots and parts, you can render accessible HTML directly in the server response. Once the
+component definition loads, the light DOM will be projected into the shadow DOM.
+
+```html
+<button data-tm-upgrade="tm-button" class="tm-surface tm-pad-sm">
+  <span class="tm-inline-flex tm-gap-xs">
+    <svg aria-hidden="true" focusable="false">…</svg>
+    <span>Checkout</span>
+  </span>
+</button>
+```
+
+Later, enhance the fallback when the island hydrates:
+
+```js
+import '@turbomini/wc-button';
+
+const upgrade = document.querySelector('[data-tm-upgrade="tm-button"]');
+if (upgrade && !upgrade.matches('tm-button')) {
+  const button = document.createElement('tm-button');
+  button.append(...upgrade.childNodes);
+  upgrade.replaceWith(button);
+}
+```
+
+This pattern plays nicely with Astro, Remix, Next.js, and other SSR frameworks—render semantic HTML on the server, then swap in
+TurboMini components only where needed.

--- a/docs/web-components/events.md
+++ b/docs/web-components/events.md
@@ -1,0 +1,26 @@
+# TurboMini Event Naming
+
+TurboMini web components namespace all custom events with the `tm-` prefix so they are easy to filter and avoid collisions with
+host application events.
+
+## Core rules
+
+- Always emit events using the `tm-` prefix. For example, use `tm-press` instead of `press`.
+- Favor the shared verbs listed below so consumers can rely on consistent semantics across components.
+- Dispatch events from the component instance (`this.emit(...)`) so they bubble and are composed by default.
+
+## Standard events
+
+| Event name | When to use it |
+| --- | --- |
+| `tm-press` | A component was activated via click, keyboard, or pointer input. |
+| `tm-change` | A value changed (inputs, toggles, radio groups). |
+| `tm-select` | A choice from a list or menu was chosen. |
+| `tm-open` | A disclosure element (dialog, drawer, dropdown) opened. |
+| `tm-close` | A disclosure element closed. |
+
+The [`TurboMiniElement`](../../packages/wc/shared/base-element.js) helper automatically prefixes events passed to
+`this.emit(name, detail)`. Passing `tm-press` keeps the prefix, while passing `press` will be converted to `tm-press` for you.
+
+When documenting a component, link back to this guide and list the specific events it emits so application developers can bind
+listeners with confidence.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "templates/*"
       ],
       "devDependencies": {
+        "@changesets/cli": "^2.27.9",
         "@eslint/js": "^9.35.0",
         "@playwright/test": "^1.55.0",
         "eslint": "^9.35.0",
@@ -21,6 +22,351 @@
         "prettier": "^3.6.2",
         "tsc": "^2.0.4",
         "typescript": "^5.9.2"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@changesets/apply-release-plan": {
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.0.13.tgz",
+      "integrity": "sha512-BIW7bofD2yAWoE8H4V40FikC+1nNFEKBisMECccS16W1rt6qqhNTBDmIw5HaqmMgtLNz9e7oiALiEUuKrQ4oHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/config": "^3.1.1",
+        "@changesets/get-version-range-type": "^0.4.0",
+        "@changesets/git": "^3.0.4",
+        "@changesets/should-skip-package": "^0.1.2",
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "detect-indent": "^6.0.0",
+        "fs-extra": "^7.0.1",
+        "lodash.startcase": "^4.4.0",
+        "outdent": "^0.5.0",
+        "prettier": "^2.7.1",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.5.3"
+      }
+    },
+    "node_modules/@changesets/apply-release-plan/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/@changesets/apply-release-plan/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@changesets/assemble-release-plan": {
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.9.tgz",
+      "integrity": "sha512-tPgeeqCHIwNo8sypKlS3gOPmsS3wP0zHt67JDuL20P4QcXiw/O4Hl7oXiuLnP9yg+rXLQ2sScdV1Kkzde61iSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/errors": "^0.2.0",
+        "@changesets/get-dependents-graph": "^2.1.3",
+        "@changesets/should-skip-package": "^0.1.2",
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "semver": "^7.5.3"
+      }
+    },
+    "node_modules/@changesets/changelog-git": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-0.2.1.tgz",
+      "integrity": "sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/types": "^6.1.0"
+      }
+    },
+    "node_modules/@changesets/cli": {
+      "version": "2.29.7",
+      "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.29.7.tgz",
+      "integrity": "sha512-R7RqWoaksyyKXbKXBTbT4REdy22yH81mcFK6sWtqSanxUCbUi9Uf+6aqxZtDQouIqPdem2W56CdxXgsxdq7FLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/apply-release-plan": "^7.0.13",
+        "@changesets/assemble-release-plan": "^6.0.9",
+        "@changesets/changelog-git": "^0.2.1",
+        "@changesets/config": "^3.1.1",
+        "@changesets/errors": "^0.2.0",
+        "@changesets/get-dependents-graph": "^2.1.3",
+        "@changesets/get-release-plan": "^4.0.13",
+        "@changesets/git": "^3.0.4",
+        "@changesets/logger": "^0.1.1",
+        "@changesets/pre": "^2.0.2",
+        "@changesets/read": "^0.6.5",
+        "@changesets/should-skip-package": "^0.1.2",
+        "@changesets/types": "^6.1.0",
+        "@changesets/write": "^0.4.0",
+        "@inquirer/external-editor": "^1.0.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "ansi-colors": "^4.1.3",
+        "ci-info": "^3.7.0",
+        "enquirer": "^2.4.1",
+        "fs-extra": "^7.0.1",
+        "mri": "^1.2.0",
+        "p-limit": "^2.2.0",
+        "package-manager-detector": "^0.2.0",
+        "picocolors": "^1.1.0",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.5.3",
+        "spawndamnit": "^3.0.1",
+        "term-size": "^2.1.0"
+      },
+      "bin": {
+        "changeset": "bin.js"
+      }
+    },
+    "node_modules/@changesets/cli/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@changesets/cli/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@changesets/config": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.1.1.tgz",
+      "integrity": "sha512-bd+3Ap2TKXxljCggI0mKPfzCQKeV/TU4yO2h2C6vAihIo8tzseAn2e7klSuiyYYXvgu53zMN1OeYMIQkaQoWnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/errors": "^0.2.0",
+        "@changesets/get-dependents-graph": "^2.1.3",
+        "@changesets/logger": "^0.1.1",
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "fs-extra": "^7.0.1",
+        "micromatch": "^4.0.8"
+      }
+    },
+    "node_modules/@changesets/errors": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@changesets/errors/-/errors-0.2.0.tgz",
+      "integrity": "sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extendable-error": "^0.1.5"
+      }
+    },
+    "node_modules/@changesets/get-dependents-graph": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-2.1.3.tgz",
+      "integrity": "sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "picocolors": "^1.1.0",
+        "semver": "^7.5.3"
+      }
+    },
+    "node_modules/@changesets/get-release-plan": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.13.tgz",
+      "integrity": "sha512-DWG1pus72FcNeXkM12tx+xtExyH/c9I1z+2aXlObH3i9YA7+WZEVaiHzHl03thpvAgWTRaH64MpfHxozfF7Dvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/assemble-release-plan": "^6.0.9",
+        "@changesets/config": "^3.1.1",
+        "@changesets/pre": "^2.0.2",
+        "@changesets/read": "^0.6.5",
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3"
+      }
+    },
+    "node_modules/@changesets/get-version-range-type": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@changesets/get-version-range-type/-/get-version-range-type-0.4.0.tgz",
+      "integrity": "sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@changesets/git": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@changesets/git/-/git-3.0.4.tgz",
+      "integrity": "sha512-BXANzRFkX+XcC1q/d27NKvlJ1yf7PSAgi8JG6dt8EfbHFHi4neau7mufcSca5zRhwOL8j9s6EqsxmT+s+/E6Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/errors": "^0.2.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "is-subdir": "^1.1.1",
+        "micromatch": "^4.0.8",
+        "spawndamnit": "^3.0.1"
+      }
+    },
+    "node_modules/@changesets/logger": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@changesets/logger/-/logger-0.1.1.tgz",
+      "integrity": "sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.1.0"
+      }
+    },
+    "node_modules/@changesets/parse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-0.4.1.tgz",
+      "integrity": "sha512-iwksMs5Bf/wUItfcg+OXrEpravm5rEd9Bf4oyIPL4kVTmJQ7PNDSd6MDYkpSJR1pn7tz/k8Zf2DhTCqX08Ou+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/types": "^6.1.0",
+        "js-yaml": "^3.13.1"
+      }
+    },
+    "node_modules/@changesets/parse/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@changesets/parse/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@changesets/pre": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-2.0.2.tgz",
+      "integrity": "sha512-HaL/gEyFVvkf9KFg6484wR9s0qjAXlZ8qWPDkTyKF6+zqjBe/I2mygg3MbpZ++hdi0ToqNUF8cjj7fBy0dg8Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/errors": "^0.2.0",
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "fs-extra": "^7.0.1"
+      }
+    },
+    "node_modules/@changesets/read": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.6.5.tgz",
+      "integrity": "sha512-UPzNGhsSjHD3Veb0xO/MwvasGe8eMyNrR/sT9gR8Q3DhOQZirgKhhXv/8hVsI0QpPjR004Z9iFxoJU6in3uGMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/git": "^3.0.4",
+        "@changesets/logger": "^0.1.1",
+        "@changesets/parse": "^0.4.1",
+        "@changesets/types": "^6.1.0",
+        "fs-extra": "^7.0.1",
+        "p-filter": "^2.1.0",
+        "picocolors": "^1.1.0"
+      }
+    },
+    "node_modules/@changesets/should-skip-package": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@changesets/should-skip-package/-/should-skip-package-0.1.2.tgz",
+      "integrity": "sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3"
+      }
+    },
+    "node_modules/@changesets/types": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-6.1.0.tgz",
+      "integrity": "sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@changesets/write": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@changesets/write/-/write-0.4.0.tgz",
+      "integrity": "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/types": "^6.1.0",
+        "fs-extra": "^7.0.1",
+        "human-id": "^4.1.1",
+        "prettier": "^2.7.1"
+      }
+    },
+    "node_modules/@changesets/write/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -214,6 +560,224 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.2.tgz",
+      "integrity": "sha512-yy9cOoBnx58TlsPrIxauKIFQTiyH+0MK4e97y4sV9ERbI+zDxw7i2hxHLCIEGIE/8PPvDxGhgzIOTSOWcs6/MQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.0",
+        "iconv-lite": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor/node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@manypkg/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@manypkg/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "@types/node": "^12.7.1",
+        "find-up": "^4.1.0",
+        "fs-extra": "^8.1.0"
+      }
+    },
+    "node_modules/@manypkg/find-root/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@manypkg/find-root/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@manypkg/find-root/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@manypkg/find-root/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@manypkg/find-root/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@manypkg/find-root/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/@manypkg/get-packages": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@manypkg/get-packages/-/get-packages-1.1.3.tgz",
+      "integrity": "sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "@changesets/types": "^4.0.1",
+        "@manypkg/find-root": "^1.1.0",
+        "fs-extra": "^8.1.0",
+        "globby": "^11.0.0",
+        "read-yaml-file": "^1.1.0"
+      }
+    },
+    "node_modules/@manypkg/get-packages/node_modules/@changesets/types": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-4.1.0.tgz",
+      "integrity": "sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@manypkg/get-packages/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@manypkg/get-packages/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@playwright/test": {
       "version": "1.55.0",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
@@ -265,6 +829,13 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -322,6 +893,26 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -343,6 +934,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -355,6 +956,19 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/better-path-resolve": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/better-path-resolve/-/better-path-resolve-1.0.0.tgz",
+      "integrity": "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-windows": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -363,6 +977,19 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -401,6 +1028,29 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.0.tgz",
+      "integrity": "sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/color-convert": {
@@ -517,6 +1167,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/detect-indent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/diff": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
@@ -524,6 +1184,19 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/domexception": {
@@ -551,6 +1224,20 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/enquirer": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
+      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.1",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8.6"
       }
     },
     "node_modules/entities": {
@@ -727,6 +1414,20 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
@@ -769,11 +1470,48 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/extendable-error": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.7.tgz",
+      "integrity": "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -787,6 +1525,16 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
+    "node_modules/fastq": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -797,6 +1545,19 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/find-up": {
@@ -848,6 +1609,31 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/fs-extra/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -920,6 +1706,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -931,6 +1738,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -1019,6 +1833,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/human-id": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/human-id/-/human-id-4.1.1.tgz",
+      "integrity": "sha512-3gKm/gCSUipeLsRYZbbdA1BD83lBoWUkZ7G9VFrhWPAU76KwYo5KR8V28bpoPm/ygy0x5/GCbpRQdY7VLYCoIg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "human-id": "dist/cli.js"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -1086,11 +1910,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
+    },
+    "node_modules/is-subdir": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-subdir/-/is-subdir-1.2.0.tgz",
+      "integrity": "sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "better-path-resolve": "1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -1170,6 +2027,16 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -1213,6 +2080,13 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "node_modules/lodash.startcase": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -1220,6 +2094,30 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
       }
     },
     "node_modules/mime-db": {
@@ -1253,6 +2151,16 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ms": {
@@ -1290,6 +2198,26 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/outdent": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.5.0.tgz",
+      "integrity": "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/p-filter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
+      "integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -1318,6 +2246,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/package-manager-detector": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.11.tgz",
+      "integrity": "sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "quansync": "^0.2.7"
       }
     },
     "node_modules/parent-module": {
@@ -1362,11 +2320,44 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/playwright": {
       "version": "1.55.0",
@@ -1443,11 +2434,89 @@
         "node": ">=6"
       }
     },
+    "node_modules/quansync": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
+      "integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/antfu"
+        },
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/sxzz"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
       "dev": true
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/read-yaml-file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-yaml-file/-/read-yaml-file-1.1.0.tgz",
+      "integrity": "sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.5",
+        "js-yaml": "^3.6.1",
+        "pify": "^4.0.1",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/read-yaml-file/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/read-yaml-file/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/requires-port": {
       "version": "1.0.0",
@@ -1464,11 +2533,46 @@
         "node": ">=4"
       }
     },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rrweb-cssom": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
       "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
       "dev": true
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -1486,6 +2590,19 @@
       },
       "engines": {
         "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/shebang-command": {
@@ -1507,6 +2624,70 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/spawndamnit": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spawndamnit/-/spawndamnit-3.0.1.tgz",
+      "integrity": "sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "cross-spawn": "^7.0.5",
+        "signal-exit": "^4.0.1"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/strip-json-comments": {
@@ -1538,6 +2719,32 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
+    },
+    "node_modules/term-size": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
+      "integrity": "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
     },
     "node_modules/tough-cookie": {
       "version": "4.1.4",

--- a/package.json
+++ b/package.json
@@ -13,11 +13,15 @@
     "build:types": "npm run build:types --workspace turbomini",
     "examples": "python -m http.server 8055",
     "format": "npx prettier -w .",
-    "lint": "node scripts/lint.mjs || true",
+    "lint": "node scripts/lint.mjs",
     "test": "npm run test --workspace turbomini",
-    "test:e2e": "npx playwright test"
+    "test:e2e": "npx playwright test",
+    "changeset": "changeset",
+    "version-packages": "changeset version",
+    "release": "changeset publish"
   },
   "devDependencies": {
+    "@changesets/cli": "^2.27.9",
     "@eslint/js": "^9.35.0",
     "@playwright/test": "^1.55.0",
     "eslint": "^9.35.0",

--- a/packages/cli/src/commands/add.js
+++ b/packages/cli/src/commands/add.js
@@ -30,6 +30,11 @@ export async function addCommand(context, args) {
           skipIfExists: !values.force,
         });
         context.logger.log(pc.green(`Installed ${tag} (copy mode).`));
+        if (values.mode == null) {
+          context.logger.log(
+            pc.dim(`Install ${tag} as a web component with: turbomini add ${name} --mode wc`)
+          );
+        }
         break;
       }
       case 'wc': {

--- a/packages/cli/src/commands/doctor.js
+++ b/packages/cli/src/commands/doctor.js
@@ -1,0 +1,141 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { diffLines } from 'diff';
+import pc from 'picocolors';
+import { parseCommandArgs } from '../utils/args.js';
+
+const THEME_FILES = ['theme.css', 'tokens.css', 'tokens.dark.css', 'tokens.json'];
+
+function renderDiff(expected, actual) {
+  const diff = diffLines(expected, actual);
+  return diff
+    .map((part) => {
+      const color = part.added ? pc.green : part.removed ? pc.red : pc.dim;
+      const prefix = part.added ? '+' : part.removed ? '-' : ' ';
+      return part.value
+        .split('\n')
+        .filter((line) => line.length > 0)
+        .map((line) => color(`${prefix} ${line}`))
+        .join('\n');
+    })
+    .filter(Boolean)
+    .join('\n');
+}
+
+async function readJson(filePath) {
+  return JSON.parse(await fs.readFile(filePath, 'utf8'));
+}
+
+export async function doctorCommand(context, args) {
+  const { values, positionals } = parseCommandArgs(args, {
+    dir: { type: 'string' },
+  });
+
+  const projectRoot = path.resolve(context.cwd, positionals[0] ?? values.dir ?? '.');
+  const packageJsonPath = path.join(projectRoot, 'package.json');
+
+  if (!(await context.fileExists(packageJsonPath))) {
+    throw new Error(`No package.json found in ${context.formatPath(projectRoot)}.`);
+  }
+
+  context.logger.log(pc.bold(`Running TurboMini doctor in ${context.formatPath(projectRoot)}`));
+
+  const projectPackageJson = await readJson(packageJsonPath);
+
+  const versionChecks = [
+    {
+      name: 'turbomini',
+      source: path.join(context.workspaceRoot, 'packages', 'core', 'package.json'),
+    },
+    {
+      name: '@turbomini/theme-base',
+      source: path.join(context.workspaceRoot, 'packages', 'themes', 'base', 'package.json'),
+    },
+  ];
+
+  const versionIssues = [];
+  for (const check of versionChecks) {
+    const expected = (await readJson(check.source)).version;
+    const declared =
+      projectPackageJson.dependencies?.[check.name] ??
+      projectPackageJson.devDependencies?.[check.name];
+
+    if (!declared) {
+      continue;
+    }
+
+    if (!declared.includes(expected)) {
+      versionIssues.push({
+        name: check.name,
+        expected,
+        declared,
+      });
+    }
+  }
+
+  const themeIssues = [];
+  const themeDir = path.join(projectRoot, 'src', 'styles', 'turbomini');
+  const canonicalDir = path.join(context.themesRoot, 'base', 'dist');
+
+  for (const fileName of THEME_FILES) {
+    const projectFile = path.join(themeDir, fileName);
+    if (!(await context.fileExists(projectFile))) {
+      themeIssues.push({
+        fileName,
+        type: 'missing',
+      });
+      continue;
+    }
+
+    const canonicalFile = path.join(canonicalDir, fileName);
+    if (!(await context.fileExists(canonicalFile))) {
+      continue;
+    }
+
+    const [expected, actual] = await Promise.all([
+      fs.readFile(canonicalFile, 'utf8'),
+      fs.readFile(projectFile, 'utf8'),
+    ]);
+
+    if (expected !== actual) {
+      themeIssues.push({
+        fileName,
+        type: 'diff',
+        diff: renderDiff(expected, actual),
+      });
+    }
+  }
+
+  if (versionIssues.length === 0 && themeIssues.length === 0) {
+    context.logger.log(pc.green('✓ No drift detected. Tokens and versions look healthy.'));
+    return;
+  }
+
+  if (versionIssues.length > 0) {
+    context.logger.log(pc.yellow(pc.bold('\nVersion drift detected:')));
+    for (const issue of versionIssues) {
+      context.logger.log(
+        pc.yellow(
+          `  • ${issue.name} is ${issue.declared}, latest workspace version is ${issue.expected}.`
+        )
+      );
+    }
+  }
+
+  if (themeIssues.length > 0) {
+    context.logger.log(pc.yellow(pc.bold('\nTheme token drift detected:')));
+    for (const issue of themeIssues) {
+      if (issue.type === 'missing') {
+        context.logger.log(pc.yellow(`  • Missing ${issue.fileName} in ${context.formatPath(themeDir)}.`));
+        continue;
+      }
+
+      context.logger.log(pc.yellow(`  • ${issue.fileName} differs from base tokens.`));
+      if (issue.diff) {
+        context.logger.log(issue.diff);
+      }
+    }
+  }
+
+  process.exitCode = 1;
+}

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -4,6 +4,7 @@ import { initCommand } from './commands/init.js';
 import { handleThemeCommand } from './commands/theme.js';
 import { addCommand } from './commands/add.js';
 import { updateCommand } from './commands/update.js';
+import { doctorCommand } from './commands/doctor.js';
 
 function parseGlobalArgs(argv) {
   const options = { dryRun: false, help: false };
@@ -40,6 +41,7 @@ function printHelp() {
     '  theme create <name>  Create a new theme override',
     '  add <component>      Install a component (copy or web component)',
     '  update <component>   Refresh local component recipes',
+    '  doctor [dir]         Check theme tokens and package versions for drift',
     '',
     'Options:',
     '  --dry-run            Preview changes without writing to disk',
@@ -77,6 +79,9 @@ async function run() {
         break;
       case 'update':
         await updateCommand(context, args);
+        break;
+      case 'doctor':
+        await doctorCommand(context, args);
         break;
       default:
         console.error(pc.red(`Unknown command: ${command}`));

--- a/packages/wc/shared/base-element.js
+++ b/packages/wc/shared/base-element.js
@@ -152,24 +152,52 @@ export class TurboMiniElement extends HTMLElement {
     if (!styles) return;
     const list = Array.isArray(styles) ? styles : [styles];
     const adoptable = [];
+    const adoptableFallback = [];
     const inline = [];
 
     for (const item of list) {
       if (!item) continue;
       if (typeof CSSStyleSheet !== 'undefined' && item instanceof CSSStyleSheet) {
         adoptable.push(item);
-      } else if (typeof item === 'string' && typeof CSSStyleSheet !== 'undefined' && 'replaceSync' in CSSStyleSheet.prototype) {
+        let cssText = '';
+        try {
+          cssText = Array.from(item.cssRules ?? []).map((rule) => rule.cssText).join('\n');
+        } catch {
+          cssText = '';
+        }
+        adoptableFallback.push(cssText || null);
+        continue;
+      }
+
+      if (typeof item === 'string' && typeof CSSStyleSheet !== 'undefined' && 'replaceSync' in CSSStyleSheet.prototype) {
         const sheet = new CSSStyleSheet();
         sheet.replaceSync(item);
         adoptable.push(sheet);
-      } else {
-        inline.push(item);
+        adoptableFallback.push(item);
+        continue;
+      }
+
+      inline.push(item);
+    }
+
+    let adopted = false;
+    if (adoptable.length && this.shadowRoot.adoptedStyleSheets !== undefined) {
+      try {
+        const current = this.shadowRoot.adoptedStyleSheets || [];
+        this.shadowRoot.adoptedStyleSheets = [...current, ...adoptable];
+        adopted = true;
+      } catch {
+        adopted = false;
       }
     }
 
-    if (adoptable.length && this.shadowRoot.adoptedStyleSheets !== undefined) {
-      const current = this.shadowRoot.adoptedStyleSheets || [];
-      this.shadowRoot.adoptedStyleSheets = [...current, ...adoptable];
+    if (!adopted) {
+      for (const cssText of adoptableFallback) {
+        if (!cssText) continue;
+        const styleEl = document.createElement('style');
+        styleEl.textContent = cssText;
+        this.shadowRoot.append(styleEl);
+      }
     }
 
     for (const item of inline) {

--- a/packages/wc/shared/package.json
+++ b/packages/wc/shared/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "description": "Shared base utilities for TurboMini web components.",
   "type": "module",
+  "sideEffects": false,
   "files": [
     "base-element.js"
   ],

--- a/packages/wc/tm-button/README.md
+++ b/packages/wc/tm-button/README.md
@@ -1,0 +1,50 @@
+# `<tm-button>`
+
+Accessible button web component that consumes TurboMini design tokens and exposes slots/parts for advanced styling.
+
+- Variants: `solid` (default), `soft`, `outline`, `ghost`
+- Sizes: `sm`, `md`, `lg`
+- Events: emits [`tm-press`](../../docs/web-components/events.md#standard-events) when activated
+
+## Token contract
+
+The component relies on the following CSS custom properties. Each token has sensible defaults wired up to
+`@turbomini/theme-base`, but you can override them at any scope.
+
+| Token | Purpose |
+| --- | --- |
+| `--tm-button-bg` | Background color for the button surface. |
+| `--tm-button-bg-hover` | Background color when hovered. |
+| `--tm-button-bg-active` | Background color when pressed. |
+| `--tm-button-fg` | Foreground text/icon color. |
+| `--tm-button-border` | Border color in the default state. |
+| `--tm-button-border-hover` | Border color on hover. |
+| `--tm-button-shadow` | Box shadow used to elevate the button. |
+| `--tm-button-radius` | Corner radius. |
+| `--tm-button-font-weight` | Font weight applied to the label. |
+| `--tm-button-font-size` | Base font size. |
+| `--tm-button-pad-y` | Vertical padding. |
+| `--tm-button-pad-x` | Horizontal padding. |
+| `--tm-button-gap` | Gap between icon/label content. |
+| `--tm-button-min-height` | Minimum inline-size/height the button should maintain. |
+
+## Shadow parts
+
+| Part | Description |
+| --- | --- |
+| `base` | The native `<button>` element that handles focus and interaction. |
+| `content` | Wrapper around the default slot, useful for spacing overrides. |
+| `indicator` | Loading spinner element that appears when `loading` is true. |
+
+## Usage
+
+```js
+import '@turbomini/wc-button';
+
+document.body.innerHTML = `
+  <tm-button variant="soft" size="lg">Action</tm-button>
+`;
+```
+
+The button inherits tokens from light or dark themes automatically. Apply `[data-theme="dark"]` or `.tm-dark` to scope dark
+mode overrides to a container instead of the entire document when needed.

--- a/packages/wc/tm-button/component.json
+++ b/packages/wc/tm-button/component.json
@@ -22,5 +22,30 @@
   ],
   "events": [
     { "name": "tm-press", "detail": "{ originalEvent: MouseEvent, value: string | null }" }
-  ]
+  ],
+  "tokens": [
+    "--tm-button-bg",
+    "--tm-button-bg-hover",
+    "--tm-button-bg-active",
+    "--tm-button-fg",
+    "--tm-button-border",
+    "--tm-button-border-hover",
+    "--tm-button-shadow",
+    "--tm-button-radius",
+    "--tm-button-font-weight",
+    "--tm-button-font-size",
+    "--tm-button-pad-y",
+    "--tm-button-pad-x",
+    "--tm-button-gap",
+    "--tm-button-min-height"
+  ],
+  "parts": [
+    "base",
+    "content",
+    "indicator"
+  ],
+  "docs": {
+    "readme": "./README.md",
+    "events": "../../../docs/web-components/events.md"
+  }
 }

--- a/templates/starter/spa/src/main.js
+++ b/templates/starter/spa/src/main.js
@@ -1,5 +1,6 @@
 import { TurboMini } from 'turbomini';
 import './styles/turbomini/theme.css';
+import './styles/app.css';
 
 const app = TurboMini('/');
 
@@ -24,6 +25,19 @@ app.template(
         </article>
       {{/each}}
     </section>
+    <section class="tm-container-demo">
+      <div class="tm-container-demo__grid">
+        <div class="tm-container-demo__content tm-stack">
+          <h2>{{containerDemo.title}}</h2>
+          <p class="tm-text-muted">{{containerDemo.description}}</p>
+          <button type="button" class="tm-container-demo__cta">{{containerDemo.cta}}</button>
+        </div>
+        <div class="tm-container-demo__metric" aria-label="{{containerDemo.metricLabel}}">
+          <span class="tm-container-demo__metric-label">{{containerDemo.metricLabel}}</span>
+          <span class="tm-container-demo__chip">{{containerDemo.metricValue}}</span>
+        </div>
+      </div>
+    </section>
   </main>
 `
 );
@@ -44,7 +58,14 @@ app.controller('default', () => ({
       title: 'Composable components',
       description: 'Install web components or copy source into your project with the CLI.'
     }
-  ]
+  ],
+  containerDemo: {
+    title: 'Container-aware layout',
+    description: 'Resize this panel and the metric snaps into place with CSS container queries.',
+    cta: 'Explore theming docs',
+    metricLabel: 'Breakpoint',
+    metricValue: '≥ 42rem'
+  }
 }));
 
 app.start();

--- a/templates/starter/spa/src/styles/app.css
+++ b/templates/starter/spa/src/styles/app.css
@@ -1,0 +1,88 @@
+.tm-container-demo {
+  border-radius: var(--tm-radius-lg);
+  border: 1px solid color-mix(in srgb, var(--tm-color-border) 80%, transparent);
+  background: color-mix(in srgb, var(--tm-color-brand-soft) 35%, transparent);
+  padding: clamp(var(--tm-space-5), 5vw, var(--tm-space-8));
+  container-type: inline-size;
+  box-shadow: var(--tm-shadow-md);
+}
+
+.tm-container-demo__grid {
+  display: grid;
+  gap: var(--tm-space-6);
+}
+
+.tm-container-demo__content {
+  gap: var(--tm-space-4);
+}
+
+.tm-container-demo__metric {
+  display: grid;
+  gap: var(--tm-space-2);
+  justify-items: start;
+}
+
+.tm-container-demo__metric-label {
+  font-size: var(--tm-font-size-xs);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--tm-color-text-muted);
+}
+
+.tm-container-demo__chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--tm-space-2) var(--tm-space-4);
+  border-radius: var(--tm-radius-full);
+  background: var(--tm-color-surface);
+  color: var(--tm-color-brand);
+  font-weight: 600;
+  box-shadow: var(--tm-shadow-sm);
+}
+
+.tm-container-demo__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--tm-space-2);
+  padding: var(--tm-space-2) var(--tm-space-4);
+  border-radius: var(--tm-radius-full);
+  border: 1px solid color-mix(in srgb, var(--tm-color-brand) 35%, transparent);
+  background: var(--tm-color-brand);
+  color: var(--tm-color-brand-contrast);
+  font-weight: 600;
+  font-size: var(--tm-font-size-sm);
+  cursor: pointer;
+  transition: transform var(--tm-motion-duration-fast) var(--tm-motion-ease-out),
+    box-shadow var(--tm-motion-duration-fast) var(--tm-motion-ease-out);
+}
+
+.tm-container-demo__cta:focus-visible {
+  outline: none;
+  box-shadow: var(--tm-focus-ring);
+}
+
+.tm-container-demo__cta:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--tm-shadow-lg);
+}
+
+@container (min-width: 42rem) {
+  .tm-container-demo__grid {
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+    align-items: center;
+  }
+
+  .tm-container-demo__metric {
+    justify-items: end;
+    text-align: right;
+  }
+}
+
+@container (min-width: 62rem) {
+  .tm-container-demo__chip {
+    font-size: var(--tm-font-size-lg);
+    padding-inline: var(--tm-space-5);
+  }
+}


### PR DESCRIPTION
## Summary
- add a `turbomini doctor` command, update CLI help text, and surface the `--mode wc` hint when copying components by default
- adopt Changesets-based release tooling, expand the CI workflow to lint/build/test/publish, and wire the supporting npm scripts
- document the tm-* event contract, component token surface, SSR guidance, and add a container-query demo while hardening the WC base element stylesheet fallback

## Testing
- npm run lint
- npm test
- npm run build
- npm run test:e2e *(fails: Playwright browsers not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d20bf53994833380081ac482c0052f