### PR TITLE
Fix CLI asset resolution and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ test-results
 coverage
 .DS_Store
 *.log
+packages/cli/templates
+packages/cli/packages

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "examples": "python -m http.server 8055",
     "format": "npx prettier -w .",
     "lint": "node scripts/lint.mjs",
-    "test": "npm run test --workspace turbomini && npm run test --workspace @turbomini/wc-tests",
+    "test": "npm run test --workspace turbomini && npm run test --workspace @turbomini/cli && npm run test --workspace @turbomini/wc-tests",
     "test:e2e": "npx playwright test",
     "changeset": "changeset",
     "version-packages": "changeset version",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,9 +6,16 @@
   "bin": {
     "turbomini": "./bin/turbomini.js"
   },
+  "scripts": {
+    "prepack": "node ./scripts/prepack.js",
+    "postpack": "node ./scripts/postpack.js",
+    "test": "node --test"
+  },
   "files": [
     "bin",
-    "src"
+    "src",
+    "templates",
+    "packages"
   ],
   "dependencies": {
     "diff": "^5.2.0",

--- a/packages/cli/scripts/copy-runtime-assets.js
+++ b/packages/cli/scripts/copy-runtime-assets.js
@@ -1,0 +1,47 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const DEFAULT_FILTER = (source) => {
+  const basename = path.basename(source);
+  return basename !== 'node_modules' && basename !== '.git';
+};
+
+async function ensureSourceExists(source) {
+  try {
+    await fs.access(source);
+  } catch {
+    throw new Error(`Missing asset directory: ${source}`);
+  }
+}
+
+async function copyDirectory(source, target) {
+  await ensureSourceExists(source);
+  await fs.rm(target, { recursive: true, force: true });
+  await fs.mkdir(path.dirname(target), { recursive: true });
+  await fs.cp(source, target, {
+    recursive: true,
+    filter: (src) => DEFAULT_FILTER(src),
+  });
+}
+
+export async function copyRuntimeAssets({ sourceRoot, targetRoot }) {
+  const entries = [
+    { from: path.join(sourceRoot, 'templates'), to: path.join(targetRoot, 'templates') },
+    { from: path.join(sourceRoot, 'packages', 'themes'), to: path.join(targetRoot, 'packages', 'themes') },
+    { from: path.join(sourceRoot, 'packages', 'wc'), to: path.join(targetRoot, 'packages', 'wc') },
+  ];
+
+  for (const entry of entries) {
+    await copyDirectory(entry.from, entry.to);
+  }
+}
+
+export async function removeRuntimeAssets(targetRoot) {
+  const targets = [
+    path.join(targetRoot, 'templates'),
+    path.join(targetRoot, 'packages', 'themes'),
+    path.join(targetRoot, 'packages', 'wc'),
+  ];
+
+  await Promise.all(targets.map((target) => fs.rm(target, { recursive: true, force: true })));
+}

--- a/packages/cli/scripts/postpack.js
+++ b/packages/cli/scripts/postpack.js
@@ -1,0 +1,8 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { removeRuntimeAssets } from './copy-runtime-assets.js';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(scriptDir, '..');
+
+await removeRuntimeAssets(packageRoot);

--- a/packages/cli/scripts/prepack.js
+++ b/packages/cli/scripts/prepack.js
@@ -1,0 +1,9 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { copyRuntimeAssets } from './copy-runtime-assets.js';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(scriptDir, '..');
+const workspaceRoot = path.resolve(packageRoot, '..', '..');
+
+await copyRuntimeAssets({ sourceRoot: workspaceRoot, targetRoot: packageRoot });

--- a/packages/cli/src/context.js
+++ b/packages/cli/src/context.js
@@ -1,4 +1,5 @@
 import fs from 'node:fs/promises';
+import fsSync from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { diffLines } from 'diff';
@@ -50,9 +51,25 @@ export function createContext(options = {}) {
   const contextDir = dirname(import.meta.url); // packages/cli/src
   const cliRoot = path.resolve(contextDir, '..');
   const workspaceRoot = path.resolve(cliRoot, '..', '..');
-  const templatesRoot = path.resolve(workspaceRoot, 'templates');
-  const componentsRoot = path.resolve(workspaceRoot, 'packages', 'wc');
-  const themesRoot = path.resolve(workspaceRoot, 'packages', 'themes');
+
+  function resolveRuntimePath(...segments) {
+    const candidates = [
+      path.resolve(cliRoot, ...segments),
+      path.resolve(workspaceRoot, ...segments),
+    ];
+
+    for (const candidate of candidates) {
+      if (fsSync.existsSync(candidate)) {
+        return candidate;
+      }
+    }
+
+    return candidates[0];
+  }
+
+  const templatesRoot = resolveRuntimePath('templates');
+  const componentsRoot = resolveRuntimePath('packages', 'wc');
+  const themesRoot = resolveRuntimePath('packages', 'themes');
 
   function formatPath(targetPath) {
     const rel = path.relative(cwd, targetPath);

--- a/packages/cli/tests/init.test.js
+++ b/packages/cli/tests/init.test.js
@@ -1,0 +1,91 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { cp, mkdtemp, mkdir, readFile, rm } from 'node:fs/promises';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { createContext } from '../src/context.js';
+import { initCommand } from '../src/commands/init.js';
+import { copyRuntimeAssets } from '../scripts/copy-runtime-assets.js';
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const cliSourceRoot = path.resolve(testDir, '..');
+const workspaceRoot = path.resolve(cliSourceRoot, '..', '..');
+
+function noopLogger() {
+  return {
+    log: () => {},
+  };
+}
+
+async function createTempDir(prefix) {
+  return mkdtemp(path.join(tmpdir(), prefix));
+}
+
+async function setupInstalledCli() {
+  const installRoot = await createTempDir('turbomini-cli-');
+  const cliInstallDir = path.join(installRoot, 'node_modules', '@turbomini', 'cli');
+
+  await copyRuntimeAssets({ sourceRoot: workspaceRoot, targetRoot: cliInstallDir });
+  await mkdir(path.join(cliInstallDir, 'src'), { recursive: true });
+  await mkdir(path.join(cliInstallDir, 'bin'), { recursive: true });
+  await cp(path.join(cliSourceRoot, 'src'), path.join(cliInstallDir, 'src'), { recursive: true });
+  await cp(path.join(cliSourceRoot, 'bin'), path.join(cliInstallDir, 'bin'), { recursive: true });
+  await mkdir(path.join(cliInstallDir, 'node_modules'), { recursive: true });
+  await cp(path.join(workspaceRoot, 'node_modules', 'diff'), path.join(cliInstallDir, 'node_modules', 'diff'), {
+    recursive: true,
+  });
+  await cp(path.join(workspaceRoot, 'node_modules', 'picocolors'), path.join(cliInstallDir, 'node_modules', 'picocolors'), {
+    recursive: true,
+  });
+
+  return { installRoot, cliInstallDir };
+}
+
+test('init scaffolds a project from workspace sources', async (t) => {
+  const tempDir = await createTempDir('turbomini-workspace-');
+  t.after(() => rm(tempDir, { recursive: true, force: true }));
+
+  const context = createContext({ cwd: tempDir, logger: noopLogger() });
+  await initCommand(context, ['demo-app']);
+
+  const packageJsonPath = path.join(tempDir, 'demo-app', 'package.json');
+  const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8'));
+  assert.equal(packageJson.name, 'demo-app');
+
+  const themeCssPath = path.join(tempDir, 'demo-app', 'src', 'styles', 'turbomini', 'theme.css');
+  const themeCss = await readFile(themeCssPath, 'utf8');
+  assert.ok(themeCss.includes('--tm-color-brand'));
+});
+
+test('init works when the CLI is installed via npm', async (t) => {
+  const { installRoot, cliInstallDir } = await setupInstalledCli();
+  t.after(() => rm(installRoot, { recursive: true, force: true }));
+
+  const contextModule = await import(pathToFileURL(path.join(cliInstallDir, 'src', 'context.js')));
+  const initModule = await import(pathToFileURL(path.join(cliInstallDir, 'src', 'commands', 'init.js')));
+
+  const context = contextModule.createContext({ cwd: installRoot, logger: noopLogger() });
+  await initModule.initCommand(context, ['installed-app']);
+
+  const packageJsonPath = path.join(installRoot, 'installed-app', 'package.json');
+  const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8'));
+  assert.equal(packageJson.name, 'installed-app');
+
+  const themeCssPath = path.join(installRoot, 'installed-app', 'src', 'styles', 'turbomini', 'theme.css');
+  const themeCss = await readFile(themeCssPath, 'utf8');
+  assert.ok(themeCss.includes('--tm-color-brand'));
+});
+
+test('component metadata is available after packaging', async (t) => {
+  const { installRoot, cliInstallDir } = await setupInstalledCli();
+  t.after(() => rm(installRoot, { recursive: true, force: true }));
+
+  const contextModule = await import(pathToFileURL(path.join(cliInstallDir, 'src', 'context.js')));
+  const componentsModule = await import(pathToFileURL(path.join(cliInstallDir, 'src', 'utils', 'components.js')));
+
+  const context = contextModule.createContext({ cwd: installRoot, logger: noopLogger() });
+  const component = await componentsModule.loadComponent(context, 'tm-button');
+  assert.equal(component.manifest.tag, 'tm-button');
+});


### PR DESCRIPTION
## Summary
- ensure the CLI resolves templates, components, and theme assets when installed from npm
- add prepack/postpack scripts that copy runtime assets into the published package
- introduce a CLI test suite that covers workspace and packaged installation scenarios

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5bba89dd083339fa74edc583478ae