### PR TITLE
Improve turbomini serve MIME type handling

### DIFF
--- a/packages/cli/src/commands/serve.js
+++ b/packages/cli/src/commands/serve.js
@@ -7,39 +7,51 @@ import { parseCommandArgs } from '../utils/args.js';
 const DEFAULT_PORT = 4173;
 const DEFAULT_HOST = '0.0.0.0';
 
+const CHARSET_TYPES = new Set([
+  'text/css',
+  'text/html',
+  'text/javascript',
+  'text/plain',
+  'application/javascript',
+  'application/json',
+  'application/manifest+json',
+  'image/svg+xml',
+]);
+
+const MIME_TYPES = new Map([
+  ['.apng', 'image/apng'],
+  ['.avif', 'image/avif'],
+  ['.css', 'text/css'],
+  ['.gif', 'image/gif'],
+  ['.html', 'text/html'],
+  ['.ico', 'image/x-icon'],
+  ['.jpeg', 'image/jpeg'],
+  ['.jpg', 'image/jpeg'],
+  ['.js', 'text/javascript'],
+  ['.json', 'application/json'],
+  ['.map', 'application/json'],
+  ['.mjs', 'text/javascript'],
+  ['.mp4', 'video/mp4'],
+  ['.otf', 'font/otf'],
+  ['.png', 'image/png'],
+  ['.svg', 'image/svg+xml'],
+  ['.txt', 'text/plain'],
+  ['.wasm', 'application/wasm'],
+  ['.webmanifest', 'application/manifest+json'],
+  ['.webp', 'image/webp'],
+  ['.woff', 'font/woff'],
+  ['.woff2', 'font/woff2'],
+]);
+
 function getContentType(filePath) {
   const ext = path.extname(filePath).toLowerCase();
-  switch (ext) {
-    case '.html':
-      return 'text/html; charset=utf-8';
-    case '.css':
-      return 'text/css; charset=utf-8';
-    case '.js':
-    case '.mjs':
-    case '.cjs':
-      return 'text/javascript; charset=utf-8';
-    case '.json':
-      return 'application/json; charset=utf-8';
-    case '.svg':
-      return 'image/svg+xml';
-    case '.png':
-      return 'image/png';
-    case '.jpg':
-    case '.jpeg':
-      return 'image/jpeg';
-    case '.gif':
-      return 'image/gif';
-    case '.webp':
-      return 'image/webp';
-    case '.ico':
-      return 'image/x-icon';
-    case '.txt':
-      return 'text/plain; charset=utf-8';
-    case '.map':
-      return 'application/json; charset=utf-8';
-    default:
-      return 'application/octet-stream';
+  const mimeType = MIME_TYPES.get(ext) ?? 'application/octet-stream';
+
+  if (CHARSET_TYPES.has(mimeType)) {
+    return `${mimeType}; charset=utf-8`;
   }
+
+  return mimeType;
 }
 
 async function readFileSafe(filePath) {

--- a/packages/cli/tests/serve.test.js
+++ b/packages/cli/tests/serve.test.js
@@ -33,6 +33,13 @@ test('serveCommand hosts static files with SPA fallback', async (t) => {
     '<!doctype html><html><body><h1>Hello SPA</h1></body></html>'
   );
   await writeFile(path.join(tempDir, 'style.css'), 'body { color: red; }');
+  await writeFile(path.join(tempDir, 'script.js'), 'export const value = 42;');
+  await writeFile(path.join(tempDir, 'data.json'), '{"hello":"world"}');
+  await writeFile(
+    path.join(tempDir, 'icon.svg'),
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1"></svg>'
+  );
+  await writeFile(path.join(tempDir, 'font.woff2'), Buffer.from([0, 1, 2, 3]));
   await mkdir(path.join(tempDir, 'nested'), { recursive: true });
   await writeFile(
     path.join(tempDir, 'nested', 'index.html'),
@@ -57,6 +64,33 @@ test('serveCommand hosts static files with SPA fallback', async (t) => {
   assert.equal(assetResponse.status, 200);
   assert.equal(assetResponse.headers.get('content-type'), 'text/css; charset=utf-8');
   assert.equal((await assetResponse.text()).trim(), 'body { color: red; }');
+
+  const scriptResponse = await fetch(`${baseUrl}/script.js`);
+  assert.equal(scriptResponse.status, 200);
+  assert.equal(
+    scriptResponse.headers.get('content-type'),
+    'text/javascript; charset=utf-8'
+  );
+  assert.equal((await scriptResponse.text()).trim(), 'export const value = 42;');
+
+  const jsonResponse = await fetch(`${baseUrl}/data.json`);
+  assert.equal(jsonResponse.status, 200);
+  assert.equal(
+    jsonResponse.headers.get('content-type'),
+    'application/json; charset=utf-8'
+  );
+  assert.equal((await jsonResponse.text()).trim(), '{"hello":"world"}');
+
+  const svgResponse = await fetch(`${baseUrl}/icon.svg`);
+  assert.equal(svgResponse.status, 200);
+  assert.equal(
+    svgResponse.headers.get('content-type'),
+    'image/svg+xml; charset=utf-8'
+  );
+
+  const fontResponse = await fetch(`${baseUrl}/font.woff2`);
+  assert.equal(fontResponse.status, 200);
+  assert.equal(fontResponse.headers.get('content-type'), 'font/woff2');
 
   const nestedResponse = await fetch(`${baseUrl}/nested/`);
   assert.equal(nestedResponse.status, 200);


### PR DESCRIPTION
## Summary
- expand the static file server MIME type map to cover additional asset extensions
- ensure charset information is included for text-based responses
- add integration tests verifying the served Content-Type headers for common assets

## Testing
- npm run test --workspace @turbomini/cli *(fails: existing init scaffolding assertions)*

------
https://chatgpt.com/codex/tasks/task_e_6904e864c18c8333b2465fb24e8ac907